### PR TITLE
Implement MVP architecture for Splash Screen logic in MainActivity ✅

### DIFF
--- a/app/src/main/java/com/iti/mealmate/splash/SplashContract.java
+++ b/app/src/main/java/com/iti/mealmate/splash/SplashContract.java
@@ -1,0 +1,16 @@
+package com.iti.mealmate.splash;
+
+import com.iti.mealmate.base.BasePresenter;
+
+public interface SplashContract {
+    interface View {
+        void navigateToOnboarding();
+        void navigateToMain();
+        void navigateToLogin();
+        void startSplashAnimations();
+    }
+
+    interface Presenter extends BasePresenter {
+        void onSplashTimeout();
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/splash/SplashPresenter.java
+++ b/app/src/main/java/com/iti/mealmate/splash/SplashPresenter.java
@@ -1,0 +1,32 @@
+package com.iti.mealmate.splash;
+
+import com.iti.mealmate.data.repo.AppStartupRepository;
+
+public class SplashPresenter implements SplashContract.Presenter {
+
+    private final SplashContract.View view;
+    private final AppStartupRepository appStartupRepository;
+
+    public SplashPresenter(SplashContract.View view, AppStartupRepository appStartupRepository) {
+        this.view = view;
+        this.appStartupRepository = appStartupRepository;
+    }
+
+    @Override
+    public void onViewCreated() {
+        view.startSplashAnimations();
+    }
+
+    @Override
+    public void onSplashTimeout() {
+        // TODO: Navigate to Home/Login after onboarding is done
+        if (appStartupRepository.isOnboardingCompleted()) {
+            view.navigateToMain();
+        } else {
+            view.navigateToOnboarding();
+        }
+    }
+
+    @Override
+    public void onDestroy() {}
+}


### PR DESCRIPTION
- Create `SplashContract` to define the View and Presenter interfaces for the splash screen.
- Implement `SplashPresenter` to handle navigation logic based on onboarding completion status retrieved from `AppStartupRepository`.
- Refactor `MainActivity` to implement `SplashContract.View` and delegate navigation decisions to the presenter.
- Implement splash animation triggering and lifecycle-aware cleanup of `Handler` callbacks in `MainActivity`.
- Integrate `ServiceLocator` in `MainActivity` to provide dependencies to the `SplashPresenter`.
- Add TODO placeholders for future navigation paths (Home/Login) while maintaining current onboarding flow consistency.