### PR TITLE
Refactor onboarding presenter binding and fragment instantiation

### DIFF
--- a/app/src/main/java/com/iti/mealmate/onboarding/view/OnboardingActivity.java
+++ b/app/src/main/java/com/iti/mealmate/onboarding/view/OnboardingActivity.java
@@ -71,7 +71,7 @@ public class OnboardingActivity extends AppCompatActivity implements OnboardingC
     @Override
     public void setupViewPager(List<OnboardingPage> pages) {
         OnboardingAdapter adapter = new OnboardingAdapter(
-                this, presenter.getPageCount(), presenter
+                this, presenter.getPageCount()
         );
         binding.viewPager.setAdapter(adapter);
         binding.dotsIndicator.attachTo(binding.viewPager);
@@ -97,6 +97,10 @@ public class OnboardingActivity extends AppCompatActivity implements OnboardingC
     @Override
     public void setSkipButtonVisible(boolean visible) {
         binding.btnSkip.setVisibility(visible ? View.VISIBLE : View.INVISIBLE);
+    }
+
+    public OnboardingContract.PagePresenter getPagePresenter() {
+        return presenter;
     }
 
     @Override

--- a/app/src/main/java/com/iti/mealmate/onboarding/view/OnboardingAdapter.java
+++ b/app/src/main/java/com/iti/mealmate/onboarding/view/OnboardingAdapter.java
@@ -4,24 +4,21 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
-import com.iti.mealmate.onboarding.OnboardingContract;
 
 
 public class OnboardingAdapter extends FragmentStateAdapter {
 
     private final int pageCount;
-    private final OnboardingContract.PagePresenter presenter;
 
-    public OnboardingAdapter(@NonNull FragmentActivity fragmentActivity, int pageCount, OnboardingContract.PagePresenter presenter) {
+    public OnboardingAdapter(@NonNull FragmentActivity fragmentActivity, int pageCount) {
         super(fragmentActivity);
         this.pageCount = pageCount;
-        this.presenter = presenter;
     }
 
     @NonNull
     @Override
     public Fragment createFragment(int position) {
-        return OnboardingPageFragment.newInstance(presenter, position);
+        return OnboardingPageFragment.newInstance(position);
     }
 
     @Override

--- a/app/src/main/java/com/iti/mealmate/onboarding/view/OnboardingPageFragment.java
+++ b/app/src/main/java/com/iti/mealmate/onboarding/view/OnboardingPageFragment.java
@@ -21,11 +21,11 @@ public class OnboardingPageFragment extends Fragment implements OnboardingContra
 
     private static final String ARG_POSITION = "position";
 
-    public static OnboardingPageFragment newInstance(
-            @NonNull OnboardingContract.PagePresenter presenter, int position) {
+    public static OnboardingPageFragment newInstance(int position) {
         OnboardingPageFragment fragment = new OnboardingPageFragment();
-        fragment.presenter = presenter;
-        fragment.saveStateToBundle(position);
+        Bundle args = new Bundle();
+        args.putInt(ARG_POSITION, position);
+        fragment.setArguments(args);
         return fragment;
     }
 
@@ -47,7 +47,24 @@ public class OnboardingPageFragment extends Fragment implements OnboardingContra
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        presenter.bindView(this, position);
+        bindPresenter();
+    }
+
+    private void bindPresenter() {
+        if (getActivity() instanceof OnboardingActivity) {
+            presenter = ((OnboardingActivity) getActivity()).getPagePresenter();
+            if (presenter != null) {
+                presenter.bindView(this, position);
+            }
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (presenter == null && binding != null) {
+            bindPresenter();
+        }
     }
 
     @Override
@@ -61,11 +78,5 @@ public class OnboardingPageFragment extends Fragment implements OnboardingContra
     public void onDestroyView() {
         super.onDestroyView();
         binding = null;
-    }
-
-    private void saveStateToBundle(int position){
-        Bundle args = new Bundle();
-        args.putInt(ARG_POSITION, position);
-        setArguments(args);
     }
 }


### PR DESCRIPTION
- Update `OnboardingPageFragment` to retrieve its presenter from the parent `OnboardingActivity` instead of receiving it via a static factory method.
- Modify `OnboardingPageFragment.newInstance` to only require a position parameter, using a standard `Bundle` for argument passing.
- Implement `bindPresenter` in `OnboardingPageFragment` to handle presenter attachment during `onViewCreated` and `onResume`.
- Simplify `OnboardingAdapter` by removing the `PagePresenter` dependency from its constructor and fragment creation logic.
- Add `getPagePresenter()` to `OnboardingActivity` to provide fragment access to the shared presenter instance.
- Remove `saveStateToBundle` helper in favor of direct inline argument setting.