### PR TITLE
Implement meal data layer with Retrofit, Firestore, and RxJava ✅

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,11 +56,12 @@ dependencies {
     implementation(libs.rxandroid)
     implementation(libs.rxjava)
     implementation(libs.firebase.firestore)
-
     implementation(libs.credentials)
     implementation(libs.credentials.play.services.auth)
     implementation(libs.googleid)
     implementation(libs.facebook.login)
-
+    implementation(libs.retrofit)
+    implementation(libs.retrofit2.converter.gson)
+    implementation(libs.adapter.rxjava2)
 
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/api/MealApiService.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/api/MealApiService.java
@@ -1,0 +1,22 @@
+package com.iti.mealmate.data.meal.api;
+
+
+import com.iti.mealmate.data.meal.model.response.MealsBaseResponse;
+import io.reactivex.rxjava3.core.Single;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+public interface MealApiService {
+    @GET("random.php")
+    Single<MealsBaseResponse> getRandomMeal();
+
+    @GET("filter.php")
+    Single<MealsBaseResponse> getMealsByIngredient(@Query("i") String ingredient);
+
+    @GET("lookup.php")
+    Single<MealsBaseResponse> getMealById(@Query("i") String id);
+
+    @GET("search.php")
+    Single<MealsBaseResponse> searchMealsByName(@Query("s") String name);
+
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/FirestoreMealHelper.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/FirestoreMealHelper.java
@@ -1,0 +1,58 @@
+package com.iti.mealmate.data.meal.datasource.remote;
+
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.iti.mealmate.data.meal.exceptions.MealNotFoundException;
+import com.iti.mealmate.data.meal.model.response.MealOfTheDay;
+
+import java.time.LocalDate;
+
+import io.reactivex.rxjava3.core.Single;
+
+public class FirestoreMealHelper {
+
+    private final FirebaseFirestore firestore;
+
+    private static final String DAILY_MEALS = "dailyMeals";
+
+
+    public FirestoreMealHelper(FirebaseFirestore firestore) {
+        this.firestore = firestore;
+    }
+
+
+    public Single<Void> saveMealOfTheDay(String mealId) {
+        MealOfTheDay meal = new MealOfTheDay(mealId, LocalDate.now().toString());
+
+        return Single.create(emitter ->
+                firestore.collection(DAILY_MEALS)
+                        .document(meal.getDate())
+                        .set(meal)
+                        .addOnSuccessListener(emitter::onSuccess)
+                        .addOnFailureListener(emitter::onError)
+        );
+    }
+
+    public Single<MealOfTheDay> getMealOfTheDay() {
+        String docId = LocalDate.now().toString();
+        return Single.create(emitter ->
+                firestore.collection(DAILY_MEALS)
+                        .document(docId)
+                        .get()
+                        .addOnSuccessListener(documentSnapshot -> {
+                            if (documentSnapshot.exists()) {
+                                MealOfTheDay meal = documentSnapshot.toObject(MealOfTheDay.class);
+                                if (meal != null) {
+                                    emitter.onSuccess(meal);
+                                } else {
+                                    emitter.onError(new MealNotFoundException("Meal data is null"));
+                                }
+                            } else {
+                                emitter.onError(new MealNotFoundException("No meal saved for today"));
+                            }
+                        })
+                        .addOnFailureListener(emitter::onError)
+        );
+    }
+
+
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSource.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSource.java
@@ -1,0 +1,17 @@
+package com.iti.mealmate.data.meal.datasource.remote;
+
+
+import com.iti.mealmate.data.meal.model.entity.Meal;
+
+import java.util.List;
+import io.reactivex.rxjava3.core.Single;
+
+public interface MealRemoteDataSource {
+    Single<Meal> getMealOfTheDay();
+
+    Single<List<Meal>> getMealsByIngredient(String ingredient);
+
+    Single<Meal> getMealById(String id);
+
+    Single<List<Meal>> searchMealsByName(String name);
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSourceImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSourceImpl.java
@@ -1,0 +1,69 @@
+package com.iti.mealmate.data.meal.datasource.remote;
+
+import com.iti.mealmate.data.meal.api.MealApiService;
+import com.iti.mealmate.data.meal.exceptions.MealNotFoundException;
+import com.iti.mealmate.data.meal.model.entity.Meal;
+import com.iti.mealmate.data.meal.model.mapper.MealMapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.reactivex.rxjava3.core.Single;
+
+public class MealRemoteDataSourceImpl implements MealRemoteDataSource {
+
+    private final MealApiService mealApiService;
+
+    private final FirestoreMealHelper firestoreMealHelper;
+
+    public MealRemoteDataSourceImpl(MealApiService mealApiService, FirestoreMealHelper firestoreMealHelper) {
+        this.mealApiService = mealApiService;
+        this.firestoreMealHelper = firestoreMealHelper;
+    }
+
+    @Override
+    public Single<Meal> getMealOfTheDay() {
+        return firestoreMealHelper.getMealOfTheDay()
+                .flatMap(mealOfTheDay -> getMealById(mealOfTheDay.getMealId())
+                                .onErrorResumeNext(error -> refreshDailyMeal()))
+                .onErrorResumeNext(error -> {
+                    if (error instanceof MealNotFoundException) {
+                        return refreshDailyMeal();
+                    }
+                    return Single.error(error);
+                });
+    }
+
+    private Single<Meal> refreshDailyMeal() {
+        return mealApiService.getRandomMeal()
+                .flatMap(mealsBaseResponse -> {
+                    Meal meal = MealMapper.toEntity(mealsBaseResponse.getMeals().get(0));
+                    return firestoreMealHelper.saveMealOfTheDay(meal.getId()).map(aVoid -> meal);
+                });
+    }
+
+
+    @Override
+    public Single<List<Meal>> getMealsByIngredient(String ingredient) {
+        return mealApiService.getMealsByIngredient(ingredient)
+                .map(mealsBaseResponse -> mealsBaseResponse
+                        .getMeals().stream()
+                        .map(MealMapper::toEntity)
+                        .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Single<Meal> getMealById(String id) {
+        return mealApiService.getMealById(id)
+                .map(mealsBaseResponse -> MealMapper.toEntity(mealsBaseResponse.getMeals().get(0)));
+    }
+
+    @Override
+    public Single<List<Meal>> searchMealsByName(String name) {
+        return mealApiService.searchMealsByName(name)
+                .map(mealsBaseResponse -> mealsBaseResponse
+                        .getMeals().stream()
+                        .map(MealMapper::toEntity)
+                        .collect(Collectors.toList()));
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/exceptions/MealNotFoundException.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/exceptions/MealNotFoundException.java
@@ -1,0 +1,8 @@
+package com.iti.mealmate.data.meal.exceptions;
+
+public class MealNotFoundException extends Exception {
+    public MealNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/entity/Meal.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/entity/Meal.java
@@ -1,0 +1,39 @@
+package com.iti.mealmate.data.meal.model.entity;
+
+import java.util.List;
+
+public class Meal {
+    private final String id;
+    private final String name;
+    private final String category;
+    private final String area;
+    private final String instructions;
+    private final String thumbnailUrl;
+    private final String youtubeUrl;
+    private final String sourceUrl;
+    private final List<MealIngredient> ingredients;
+
+    public Meal(String id, String name, String category, String area,
+                String instructions, String thumbnailUrl, String youtubeUrl,
+                String sourceUrl, List<MealIngredient> ingredients) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.area = area;
+        this.instructions = instructions;
+        this.thumbnailUrl = thumbnailUrl;
+        this.youtubeUrl = youtubeUrl;
+        this.sourceUrl = sourceUrl;
+        this.ingredients = ingredients;
+    }
+
+    public String getId() { return id; }
+    public String getName() { return name; }
+    public String getCategory() { return category; }
+    public String getArea() { return area; }
+    public String getInstructions() { return instructions; }
+    public String getThumbnailUrl() { return thumbnailUrl; }
+    public String getYoutubeUrl() { return youtubeUrl; }
+    public String getSourceUrl() { return sourceUrl; }
+    public List<MealIngredient> getIngredients() { return ingredients; }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/entity/MealIngredient.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/entity/MealIngredient.java
@@ -1,0 +1,29 @@
+package com.iti.mealmate.data.meal.model.entity;
+
+import java.text.Normalizer;
+
+public class MealIngredient {
+    private final String name;
+    private final String measure;
+
+    public MealIngredient(String name, String measure) {
+        this.name = name != null ? name.trim() : "";
+        this.measure = measure != null ? measure.trim() : "";
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getMeasure() {
+        return measure;
+    }
+
+    public String getImageUrl() {
+        if (name.isEmpty()) return"";
+        String normalized = Normalizer.normalize(name, Normalizer.Form.NFD)
+                .toLowerCase()
+                .replace(" ", "_");
+        return "https://www.themealdb.com/images/ingredients/" + normalized + ".png";
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/mapper/MealMapper.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/mapper/MealMapper.java
@@ -1,0 +1,35 @@
+package com.iti.mealmate.data.meal.model.mapper;
+
+import com.iti.mealmate.data.meal.model.entity.Meal;
+import com.iti.mealmate.data.meal.model.entity.MealIngredient;
+import com.iti.mealmate.data.meal.model.response.MealResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MealMapper {
+
+    public static Meal toEntity(MealResponse response) {
+        List<MealIngredient> ingredients = new ArrayList<>();
+
+        for (int i = 1; i <= 20; i++) {
+            String ingredient = response.getStrIngredient(i);
+            String measure = response.getStrMeasure(i);
+
+            if (ingredient != null && !ingredient.trim().isEmpty()) {
+                ingredients.add(new MealIngredient(ingredient, measure != null ? measure : ""));
+            }
+        }
+
+        return new Meal(
+                response.getIdMeal(),
+                response.getStrMeal(),
+                response.getStrCategory(),
+                response.getStrArea(),
+                response.getStrInstructions(),
+                response.getStrMealThumb(),
+                response.getStrYoutube(),
+                response.getStrSource(),
+                ingredients
+        );
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/response/MealOfTheDay.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/response/MealOfTheDay.java
@@ -1,0 +1,23 @@
+package com.iti.mealmate.data.meal.model.response;
+
+import androidx.annotation.NonNull;
+
+public class MealOfTheDay {
+    private final String  mealId;
+    private final String date;
+
+    public MealOfTheDay(String mealId, @NonNull String date) {
+        this.mealId = mealId;
+        this.date = date;
+    }
+
+    public String getMealId() {
+        return mealId;
+    }
+
+    @NonNull
+    public String getDate() {
+        return date;
+    }
+
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/response/MealResponse.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/response/MealResponse.java
@@ -1,0 +1,154 @@
+package com.iti.mealmate.data.meal.model.response;
+
+import com.google.gson.annotations.SerializedName;
+
+public class MealResponse {
+
+    @SerializedName("idMeal")
+    private String idMeal;
+
+    @SerializedName("strMeal")
+    private String strMeal;
+
+    @SerializedName("strMealAlternate")
+    private String strMealAlternate;
+
+    @SerializedName("strCategory")
+    private String strCategory;
+
+    @SerializedName("strArea")
+    private String strArea;
+
+    @SerializedName("strInstructions")
+    private String strInstructions;
+
+    @SerializedName("strMealThumb")
+    private String strMealThumb;
+
+    @SerializedName("strTags")
+    private String strTags;
+
+    @SerializedName("strYoutube")
+    private String strYoutube;
+
+    @SerializedName("strIngredient1") private String strIngredient1;
+    @SerializedName("strIngredient2") private String strIngredient2;
+    @SerializedName("strIngredient3") private String strIngredient3;
+    @SerializedName("strIngredient4") private String strIngredient4;
+    @SerializedName("strIngredient5") private String strIngredient5;
+    @SerializedName("strIngredient6") private String strIngredient6;
+    @SerializedName("strIngredient7") private String strIngredient7;
+    @SerializedName("strIngredient8") private String strIngredient8;
+    @SerializedName("strIngredient9") private String strIngredient9;
+    @SerializedName("strIngredient10") private String strIngredient10;
+    @SerializedName("strIngredient11") private String strIngredient11;
+    @SerializedName("strIngredient12") private String strIngredient12;
+    @SerializedName("strIngredient13") private String strIngredient13;
+    @SerializedName("strIngredient14") private String strIngredient14;
+    @SerializedName("strIngredient15") private String strIngredient15;
+    @SerializedName("strIngredient16") private String strIngredient16;
+    @SerializedName("strIngredient17") private String strIngredient17;
+    @SerializedName("strIngredient18") private String strIngredient18;
+    @SerializedName("strIngredient19") private String strIngredient19;
+    @SerializedName("strIngredient20") private String strIngredient20;
+
+    @SerializedName("strMeasure1") private String strMeasure1;
+    @SerializedName("strMeasure2") private String strMeasure2;
+    @SerializedName("strMeasure3") private String strMeasure3;
+    @SerializedName("strMeasure4") private String strMeasure4;
+    @SerializedName("strMeasure5") private String strMeasure5;
+    @SerializedName("strMeasure6") private String strMeasure6;
+    @SerializedName("strMeasure7") private String strMeasure7;
+    @SerializedName("strMeasure8") private String strMeasure8;
+    @SerializedName("strMeasure9") private String strMeasure9;
+    @SerializedName("strMeasure10") private String strMeasure10;
+    @SerializedName("strMeasure11") private String strMeasure11;
+    @SerializedName("strMeasure12") private String strMeasure12;
+    @SerializedName("strMeasure13") private String strMeasure13;
+    @SerializedName("strMeasure14") private String strMeasure14;
+    @SerializedName("strMeasure15") private String strMeasure15;
+    @SerializedName("strMeasure16") private String strMeasure16;
+    @SerializedName("strMeasure17") private String strMeasure17;
+    @SerializedName("strMeasure18") private String strMeasure18;
+    @SerializedName("strMeasure19") private String strMeasure19;
+    @SerializedName("strMeasure20") private String strMeasure20;
+
+    @SerializedName("strSource")
+    private String strSource;
+
+    @SerializedName("strImageSource")
+    private String strImageSource;
+
+    @SerializedName("strCreativeCommonsConfirmed")
+    private String strCreativeCommonsConfirmed;
+
+    @SerializedName("dateModified")
+    private String dateModified;
+
+    public String getIdMeal() { return idMeal; }
+    public String getStrMeal() { return strMeal; }
+    public String getStrMealAlternate() { return strMealAlternate; }
+    public String getStrCategory() { return strCategory; }
+    public String getStrArea() { return strArea; }
+    public String getStrInstructions() { return strInstructions; }
+    public String getStrMealThumb() { return strMealThumb; }
+    public String getStrTags() { return strTags; }
+    public String getStrYoutube() { return strYoutube; }
+
+    public String getStrIngredient(int index) {
+        switch (index) {
+            case 1: return strIngredient1;
+            case 2: return strIngredient2;
+            case 3: return strIngredient3;
+            case 4: return strIngredient4;
+            case 5: return strIngredient5;
+            case 6: return strIngredient6;
+            case 7: return strIngredient7;
+            case 8: return strIngredient8;
+            case 9: return strIngredient9;
+            case 10: return strIngredient10;
+            case 11: return strIngredient11;
+            case 12: return strIngredient12;
+            case 13: return strIngredient13;
+            case 14: return strIngredient14;
+            case 15: return strIngredient15;
+            case 16: return strIngredient16;
+            case 17: return strIngredient17;
+            case 18: return strIngredient18;
+            case 19: return strIngredient19;
+            case 20: return strIngredient20;
+            default: return null;
+        }
+    }
+
+    public String getStrMeasure(int index) {
+        switch (index) {
+            case 1: return strMeasure1;
+            case 2: return strMeasure2;
+            case 3: return strMeasure3;
+            case 4: return strMeasure4;
+            case 5: return strMeasure5;
+            case 6: return strMeasure6;
+            case 7: return strMeasure7;
+            case 8: return strMeasure8;
+            case 9: return strMeasure9;
+            case 10: return strMeasure10;
+            case 11: return strMeasure11;
+            case 12: return strMeasure12;
+            case 13: return strMeasure13;
+            case 14: return strMeasure14;
+            case 15: return strMeasure15;
+            case 16: return strMeasure16;
+            case 17: return strMeasure17;
+            case 18: return strMeasure18;
+            case 19: return strMeasure19;
+            case 20: return strMeasure20;
+            default: return null;
+        }
+    }
+
+    public String getStrSource() { return strSource; }
+    public String getStrImageSource() { return strImageSource; }
+    public String getStrCreativeCommonsConfirmed() { return strCreativeCommonsConfirmed; }
+    public String getDateModified() { return dateModified; }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/response/MealsBaseResponse.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/response/MealsBaseResponse.java
@@ -1,0 +1,23 @@
+package com.iti.mealmate.data.meal.model.response;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class MealsBaseResponse {
+    @SerializedName("meals")
+    private List<MealResponse> meals;
+
+    public MealsBaseResponse(List<MealResponse> meals) {
+        this.meals = meals;
+    }
+
+    public List<MealResponse> getMeals() {
+        return meals;
+    }
+
+    public void setMeals(List<MealResponse> meals) {
+        this.meals = meals;
+    }
+
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepository.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepository.java
@@ -1,0 +1,18 @@
+package com.iti.mealmate.data.meal.repo;
+
+import com.iti.mealmate.data.meal.model.entity.Meal;
+
+import java.util.List;
+
+import io.reactivex.rxjava3.core.Single;
+
+public interface MealRepository {
+
+    Single<Meal> getMealOfTheDay();
+
+    Single<List<Meal>> getMealsByIngredient(String ingredient);
+
+    Single<Meal> getMealById(String id);
+
+    Single<List<Meal>> searchMealsByName(String name);
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepositoryImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.iti.mealmate.data.meal.repo;
+
+import com.iti.mealmate.data.meal.datasource.remote.MealRemoteDataSource;
+import com.iti.mealmate.data.meal.model.entity.Meal;
+
+import java.util.List;
+
+import io.reactivex.rxjava3.core.Single;
+
+class MealRepositoryImpl implements MealRepository {
+
+    private final MealRemoteDataSource remoteDataSource;
+
+    public MealRepositoryImpl(MealRemoteDataSource remoteDataSource) {
+        this.remoteDataSource = remoteDataSource;
+    }
+
+    @Override
+    public Single<Meal> getMealOfTheDay() {
+        return remoteDataSource.getMealOfTheDay();
+    }
+
+    @Override
+    public Single<List<Meal>> getMealsByIngredient(String ingredient) {
+        return remoteDataSource.getMealsByIngredient(ingredient);
+    }
+
+    @Override
+    public Single<Meal> getMealById(String id) {
+        return remoteDataSource.getMealById(id);
+    }
+
+    @Override
+    public Single<List<Meal>> searchMealsByName(String name) {
+        return remoteDataSource.searchMealsByName(name);
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/source/remote/api/ApiClient.java
+++ b/app/src/main/java/com/iti/mealmate/data/source/remote/api/ApiClient.java
@@ -1,0 +1,27 @@
+package com.iti.mealmate.data.source.remote.api;
+
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class ApiClient {
+
+    private static Retrofit instance = null;
+    private final static String BASE_URL = "www.themealdb.com/api/json/v1/1/";
+
+    private ApiClient(){}
+
+
+    public static Retrofit getInstance(){
+        if(instance == null){
+            synchronized (ApiClient.class) {
+                instance = new Retrofit.Builder()
+                        .baseUrl(BASE_URL)
+                        .addConverterFactory(GsonConverterFactory.create())
+                        .build();
+
+            }
+        }
+
+        return  instance;
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
+adapterRxjava2 = "3.0.0"
 agp = "9.0.0"
+converterGson = "3.0.0"
 coreSplashscreen = "1.2.0"
 credentials = "1.5.0"
 dotsindicator = "5.1.0"
@@ -16,10 +18,12 @@ constraintlayout = "2.2.1"
 navigationFragment = "2.9.7"
 fragment = "1.8.9"
 navigationUi = "2.9.7"
+retrofit = "3.0.0"
 rxandroid = "3.0.2"
 rxjava = "3.1.12"
 
 [libraries]
+adapter-rxjava2 = { module = "com.squareup.retrofit2:adapter-rxjava2", version.ref = "adapterRxjava2" }
 core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 credentials = { module = "androidx.credentials:credentials", version.ref = "credentials" }
 credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
@@ -39,6 +43,8 @@ constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayo
 navigation-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "navigationFragment" }
 fragment = { group = "androidx.fragment", name = "fragment", version.ref = "fragment" }
 navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigationUi" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit2-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }
 rxandroid = { module = "io.reactivex.rxjava3:rxandroid", version.ref = "rxandroid" }
 rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava" }
 


### PR DESCRIPTION
- Implement `ApiClient` using Retrofit with Gson converter for network requests.
- Create `MealApiService` interface with endpoints for random meals, filtering by ingredient, lookup by ID, and searching by name.
- Implement `MealRemoteDataSource` and its implementation `MealRemoteDataSourceImpl`:
    - Integrate `FirestoreMealHelper` to cache and retrieve a "Meal of the Day."
    - Implement logic to refresh the daily meal using a random API call if not found or expired in Firestore.
    - Provide methods for fetching meals by ingredient, ID, and name.
- Define domain models `Meal` and `MealIngredient`, including a utility in `MealIngredient` to generate ingredient image URLs.
- Implement `MealMapper` to transform API response objects (`MealResponse`) into domain entities.
- Create `MealRepository` and `MealRepositoryImpl` to act as the single entry point for meal data.
- Add `MealNotFoundException` for specific error handling in the data layer.
- Update `libs.versions.toml` and `build.gradle.kts` with `retrofit`, `converter-gson`, and `adapter-rxjava2` dependencies.