### PR TITLE
Enhance meal data layer with suggested meals and RxJava integration

### DIFF
--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSource.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSource.java
@@ -11,7 +11,7 @@ public interface MealRemoteDataSource {
 
     Single<List<Meal>> getMealsByIngredient(String ingredient);
 
-    Single<Meal> getMealById(String id);
-
     Single<List<Meal>> searchMealsByName(String name);
+
+    public Single<List<Meal>> getSuggestedMeals();
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepository.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepository.java
@@ -12,7 +12,7 @@ public interface MealRepository {
 
     Single<List<Meal>> getMealsByIngredient(String ingredient);
 
-    Single<Meal> getMealById(String id);
+    Single<List<Meal>> getSuggestedMeals();
 
     Single<List<Meal>> searchMealsByName(String name);
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepositoryImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepositoryImpl.java
@@ -26,8 +26,8 @@ class MealRepositoryImpl implements MealRepository {
     }
 
     @Override
-    public Single<Meal> getMealById(String id) {
-        return remoteDataSource.getMealById(id);
+    public Single<List<Meal>> getSuggestedMeals() {
+        return remoteDataSource.getSuggestedMeals();
     }
 
     @Override

--- a/app/src/main/java/com/iti/mealmate/data/source/remote/api/ApiClient.java
+++ b/app/src/main/java/com/iti/mealmate/data/source/remote/api/ApiClient.java
@@ -1,6 +1,7 @@
 package com.iti.mealmate.data.source.remote.api;
 
 import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public class ApiClient {
@@ -17,6 +18,7 @@ public class ApiClient {
                 instance = new Retrofit.Builder()
                         .baseUrl(BASE_URL)
                         .addConverterFactory(GsonConverterFactory.create())
+                        .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                         .build();
 
             }


### PR DESCRIPTION
- Implement `getSuggestedMeals` in `MealRemoteDataSourceImpl` using `Observable.range` and `flatMap` to fetch multiple random meals from the API.
- Update `MealRemoteDataSource` and `MealRepository` interfaces to include `getSuggestedMeals` and remove the public `getMealById` method.
- Change access modifier of `getMealById` to private in `MealRemoteDataSourceImpl` as it is now used only as an internal helper.
- Update `MealRepositoryImpl` to reflect changes in the repository interface.
- Configure `ApiClient` with `RxJava2CallAdapterFactory` to support RxJava return types in Retrofit services.