### PR TITLE
Implement Room database for local meal persistence and planning ✅

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,5 +66,9 @@ dependencies {
     implementation(libs.glide)
     implementation(libs.shimmer)
     implementation(libs.android.youtube.player)
+    implementation(libs.room.runtime)
+    implementation(libs.room.rxjava3)
+    annotationProcessor(libs.room.compiler)
+
 
 }

--- a/app/src/main/java/com/iti/mealmate/core/util/DateUtils.java
+++ b/app/src/main/java/com/iti/mealmate/core/util/DateUtils.java
@@ -1,0 +1,17 @@
+package com.iti.mealmate.core.util;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+public final class DateUtils {
+
+    private DateUtils() {
+    }
+
+    public static long todayAtStartOfDay() {
+        return LocalDate.now()
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli();
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/converter/CacheTypeConverter.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/converter/CacheTypeConverter.java
@@ -1,0 +1,21 @@
+package com.iti.mealmate.data.meal.datasource.local.converter;
+
+import androidx.room.TypeConverter;
+import com.iti.mealmate.data.meal.datasource.local.entity.CacheType;
+
+public class CacheTypeConverter {
+
+    @TypeConverter
+    public static String fromEnum(CacheType cacheType) {
+        return cacheType == null ? CacheType.NONE.name() : cacheType.name();
+    }
+
+    @TypeConverter
+    public static CacheType fromString(String value) {
+        try {
+            return value == null ? CacheType.NONE : CacheType.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return CacheType.NONE;
+        }
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/converter/MealIngredientConverter.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/converter/MealIngredientConverter.java
@@ -1,0 +1,22 @@
+package com.iti.mealmate.data.meal.datasource.local.converter;
+
+import androidx.room.TypeConverter;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.iti.mealmate.data.meal.model.entity.MealIngredient;
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class MealIngredientConverter {
+
+    @TypeConverter
+    public static String fromList(List<MealIngredient> ingredients) {
+        return new Gson().toJson(ingredients);
+    }
+
+    @TypeConverter
+    public static List<MealIngredient> fromString(String value) {
+        Type listType = new TypeToken<List<MealIngredient>>() {}.getType();
+        return new Gson().fromJson(value, listType);
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/dao/MealDao.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/dao/MealDao.java
@@ -1,0 +1,43 @@
+package com.iti.mealmate.data.meal.datasource.local.dao;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import com.iti.mealmate.data.meal.datasource.local.entity.CacheType;
+import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.Flowable;
+import java.util.List;
+
+@Dao
+public interface MealDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    Completable insertMeals(List<MealEntity> meals);
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    Completable insertMeal(MealEntity meal);
+
+    @Query("SELECT * FROM meals WHERE id = :mealId LIMIT 1")
+    Flowable<MealEntity> getMealById(String mealId);
+
+    @Query("SELECT * FROM meals WHERE cacheType = :type ORDER BY cachedDate DESC")
+    Flowable<List<MealEntity>> getMealsByType(CacheType type);
+
+    @Query("SELECT * FROM meals WHERE isFavorite = 1")
+    Flowable<List<MealEntity>> getFavorites();
+
+    @Query("UPDATE meals SET isFavorite = 1 WHERE id = :mealId")
+    Completable addToFavorites(String mealId);
+
+    @Query("UPDATE meals SET isFavorite = 0 WHERE id = :mealId")
+    Completable removeFromFavorites(String mealId);
+
+    @Query("SELECT isFavorite FROM meals WHERE id = :mealId")
+    Single<Boolean> isFavorite(String mealId);
+
+    @Query("DELETE FROM meals")
+    Completable deleteAllMeals();
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/dao/PlanDao.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/dao/PlanDao.java
@@ -1,0 +1,39 @@
+package com.iti.mealmate.data.meal.datasource.local.dao;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Transaction;
+import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
+import com.iti.mealmate.data.meal.datasource.local.entity.PlannedMealsEntity;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import java.util.List;
+
+@Dao
+public interface PlanDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    Completable addToPlan(PlannedMealsEntity plan);
+
+    @Transaction
+    @Query("SELECT m.* FROM meals m " +
+            "INNER JOIN planned_meals p ON m.id = p.mealId " +
+            "WHERE p.weekStartDate = :weekStart " +
+            "ORDER BY CASE p.dayName " +
+            "WHEN 'MONDAY' THEN 1 " +
+            "WHEN 'TUESDAY' THEN 2 " +
+            "WHEN 'WEDNESDAY' THEN 3 " +
+            "WHEN 'THURSDAY' THEN 4 " +
+            "WHEN 'FRIDAY' THEN 5 " +
+            "WHEN 'SATURDAY' THEN 6 " +
+            "WHEN 'SUNDAY' THEN 7 END")
+    Flowable<List<MealEntity>> getPlannedMealsForWeek(String weekStart);
+
+    @Query("DELETE FROM planned_meals WHERE weekStartDate = :weekStart AND dayName = :dayName")
+    Completable removeFromPlan(String weekStart, String dayName);
+
+    @Query("DELETE FROM planned_meals")
+    Completable clearAllPlans();
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/CacheType.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/CacheType.java
@@ -1,0 +1,7 @@
+package com.iti.mealmate.data.meal.datasource.local.entity;
+
+public enum CacheType {
+    DAILY,
+    TRENDING,
+    NONE
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/MealEntity.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/MealEntity.java
@@ -1,0 +1,59 @@
+package com.iti.mealmate.data.meal.datasource.local.entity;
+
+import androidx.annotation.NonNull;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+import com.iti.mealmate.core.util.DateUtils;
+import com.iti.mealmate.data.meal.model.entity.MealIngredient;
+import java.util.List;
+
+@Entity(tableName = "meals")
+public class MealEntity {
+
+    @PrimaryKey
+    @NonNull
+    public String id;
+
+    public String name;
+    public String category;
+    public String area;
+    public String instructions;
+    public String thumbnailUrl;
+    public String youtubeUrl;
+    public String sourceUrl;
+
+    public List<MealIngredient> ingredients;
+    public boolean isFavorite;
+
+    @NonNull
+    public CacheType cacheType;
+    public Long cachedDate;
+
+    public MealEntity(@NonNull String id,
+                      String name,
+                      String category,
+                      String area,
+                      String instructions,
+                      String thumbnailUrl,
+                      String youtubeUrl,
+                      String sourceUrl,
+                      List<MealIngredient> ingredients,
+                      boolean isFavorite,
+                      @NonNull CacheType cacheType,
+                      Long cachedDate) {
+
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.area = area;
+        this.instructions = instructions;
+        this.thumbnailUrl = thumbnailUrl;
+        this.youtubeUrl = youtubeUrl;
+        this.sourceUrl = sourceUrl;
+        this.ingredients = ingredients;
+        this.isFavorite = isFavorite;
+        this.cacheType = cacheType;
+        this.cachedDate = cachedDate;
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/PlannedMealsEntity.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/PlannedMealsEntity.java
@@ -1,0 +1,45 @@
+package com.iti.mealmate.data.meal.datasource.local.entity;
+
+import androidx.annotation.NonNull;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Index;
+
+@Entity(
+        tableName = "planned_meals",
+        primaryKeys = {"mealId", "weekStartDate", "dayName"},
+        indices = {
+                @Index("mealId"),
+                @Index("weekStartDate"),
+                @Index(value = {"weekStartDate", "dayName"})
+        },
+        foreignKeys = {
+                @ForeignKey(
+                        entity = MealEntity.class,
+                        parentColumns = "id",
+                        childColumns = "mealId",
+                        onDelete = ForeignKey.CASCADE
+                )
+        }
+)
+public class PlannedMealsEntity {
+
+    @NonNull
+    public String mealId;
+
+    @NonNull
+    public String dayName;
+
+    @NonNull
+    public String weekStartDate;
+
+    public Long plannedDate;
+
+    public PlannedMealsEntity(@NonNull String mealId, @NonNull String dayName,
+                              @NonNull String weekStartDate, Long plannedDate) {
+        this.mealId = mealId;
+        this.dayName = dayName;
+        this.weekStartDate = weekStartDate;
+        this.plannedDate = plannedDate;
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/source/local/db/AppDatabase.java
+++ b/app/src/main/java/com/iti/mealmate/data/source/local/db/AppDatabase.java
@@ -1,0 +1,43 @@
+package com.iti.mealmate.data.source.local.db;
+
+import android.content.Context;
+import androidx.room.Database;
+import androidx.room.Room;
+import androidx.room.RoomDatabase;
+import androidx.room.TypeConverters;
+
+import com.iti.mealmate.data.meal.datasource.local.converter.CacheTypeConverter;
+import com.iti.mealmate.data.meal.datasource.local.dao.MealDao;
+import com.iti.mealmate.data.meal.datasource.local.dao.PlanDao;
+import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
+import com.iti.mealmate.data.meal.datasource.local.entity.PlannedMealsEntity;
+import com.iti.mealmate.data.meal.datasource.local.converter.MealIngredientConverter;
+
+@Database(entities = {
+    MealEntity.class,
+    PlannedMealsEntity.class
+}, version = 1, exportSchema = false)
+@TypeConverters({MealIngredientConverter.class, CacheTypeConverter.class})
+public abstract class AppDatabase extends RoomDatabase {
+
+    private static volatile AppDatabase INSTANCE;
+    private static final String DATABASE_NAME = "mealmate_db";
+
+    public abstract MealDao mealDao();
+    public abstract PlanDao planDao();
+
+    public static AppDatabase getInstance(Context context) {
+        if (INSTANCE == null) {
+            synchronized (AppDatabase.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = Room.databaseBuilder(
+                            context.getApplicationContext(),
+                            AppDatabase.class,
+                            DATABASE_NAME
+                    ).build();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/di/ServiceLocator.java
+++ b/app/src/main/java/com/iti/mealmate/di/ServiceLocator.java
@@ -25,6 +25,7 @@ import com.iti.mealmate.data.filter.repo.FilterRepository;
 import com.iti.mealmate.data.filter.repo.FilterRepositoryImpl;
 import com.iti.mealmate.data.meal.repo.MealRepository;
 import com.iti.mealmate.data.meal.repo.MealRepositoryImpl;
+import com.iti.mealmate.data.source.local.db.AppDatabase;
 import com.iti.mealmate.data.source.local.prefs.PreferencesHelper;
 import com.iti.mealmate.data.source.remote.api.ApiClient;
 import com.iti.mealmate.data.source.remote.firebase.FirebaseAuthHelper;
@@ -40,6 +41,8 @@ public final class ServiceLocator {
     private static FilterRepository filterRepository;
     private static AppConnectivityManager connectivityManager;
 
+    private static AppDatabase appDatabase;
+
     private ServiceLocator() {}
 
     public static synchronized void init(Context context) {
@@ -47,6 +50,7 @@ public final class ServiceLocator {
         Context appContext = context.getApplicationContext();
         preferencesHelper = new PreferencesHelper(appContext);
         connectivityManager = new AppConnectivityManagerImpl(appContext);
+        appDatabase = AppDatabase.getInstance(appContext);
         if (FirebaseApp.getApps(appContext).isEmpty()) {
             FirebaseApp.initializeApp(appContext);
         }
@@ -106,6 +110,7 @@ public final class ServiceLocator {
         checkInit();
         return connectivityManager;
     }
+
 
     private static void checkInit() {
         if (!initialized) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ navigationFragment = "2.9.7"
 fragment = "1.8.9"
 navigationUi = "2.9.7"
 retrofit = "3.0.0"
+roomCompiler = "2.8.4"
+roomRuntime = "2.8.4"
+roomRxjava3 = "2.8.4"
 rxandroid = "3.0.2"
 rxjava = "3.1.12"
 shimmer = "0.5.0"
@@ -48,6 +51,9 @@ fragment = { group = "androidx.fragment", name = "fragment", version.ref = "frag
 navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigationUi" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit2-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }
+room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
+room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
+room-rxjava3 = { module = "androidx.room:room-rxjava3", version.ref = "roomRxjava3" }
 rxandroid = { module = "io.reactivex.rxjava3:rxandroid", version.ref = "rxandroid" }
 rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava" }
 shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }


### PR DESCRIPTION
- Define `MealEntity` and `PlannedMealsEntity` to represent local database tables for meals and weekly plans.
- Create `MealDao` and `PlanDao` with RxJava 3 support for managing meal caching, favorites, and scheduling.
- Implement `AppDatabase` as a singleton to provide DAO instances.
- Introduce `MealIngredientConverter` and `CacheTypeConverter` for Room serialization of custom types and enums.
- Update `ServiceLocator` to initialize and provide the `AppDatabase` instance.
- Add Room dependencies (`runtime`, `rxjava3`, `compiler`) to `build.gradle.kts` and `libs.versions.toml`.
- Add `DateUtils` utility for handling epoch-based date calculations.
- Configure foreign key constraints and indices in `PlannedMealsEntity` for data integrity.