### PR TITLE
Integrate favorite status into meal data layer and repository ✅

### DIFF
--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/favorite/FavoriteLocalDataSource.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/favorite/FavoriteLocalDataSource.java
@@ -1,0 +1,20 @@
+package com.iti.mealmate.data.meal.datasource.local.datasource.favorite;
+
+import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
+
+import java.util.List;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+
+public interface FavoriteLocalDataSource {
+
+    Flowable<List<MealEntity>> getUserFavorites();
+
+    Completable addToFavorites(String mealId);
+
+    Completable removeFromFavorites(String mealId);
+
+    Single<Boolean> isFavorite(String mealId);
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/favorite/FavoriteLocalDataSourceImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/favorite/FavoriteLocalDataSourceImpl.java
@@ -1,0 +1,39 @@
+package com.iti.mealmate.data.meal.datasource.local.datasource.favorite;
+
+import com.iti.mealmate.data.meal.datasource.local.dao.MealDao;
+import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
+
+import java.util.List;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+
+public class FavoriteLocalDataSourceImpl implements FavoriteLocalDataSource {
+
+    private final MealDao mealDao;
+
+    public FavoriteLocalDataSourceImpl(MealDao mealDao) {
+        this.mealDao = mealDao;
+    }
+
+    @Override
+    public Flowable<List<MealEntity>> getUserFavorites() {
+        return mealDao.getFavorites();
+    }
+
+    @Override
+    public Completable addToFavorites(String mealId) {
+        return mealDao.addToFavorites(mealId);
+    }
+
+    @Override
+    public Completable removeFromFavorites(String mealId) {
+        return mealDao.removeFromFavorites(mealId);
+    }
+
+    @Override
+    public Single<Boolean> isFavorite(String mealId) {
+        return mealDao.isFavorite(mealId).onErrorReturn(throwable -> false);
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/MealEntity.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/MealEntity.java
@@ -7,28 +7,27 @@ import androidx.room.PrimaryKey;
 import com.iti.mealmate.core.util.DateUtils;
 import com.iti.mealmate.data.meal.model.entity.MealIngredient;
 import java.util.List;
-
 @Entity(tableName = "meals")
 public class MealEntity {
 
     @PrimaryKey
     @NonNull
-    public String id;
+    private String id;
 
-    public String name;
-    public String category;
-    public String area;
-    public String instructions;
-    public String thumbnailUrl;
-    public String youtubeUrl;
-    public String sourceUrl;
+    private String name;
+    private String category;
+    private String area;
+    private String instructions;
+    private String thumbnailUrl;
+    private String youtubeUrl;
+    private String sourceUrl;
 
-    public List<MealIngredient> ingredients;
-    public boolean isFavorite;
+    private List<MealIngredient> ingredients;
+    private boolean isFavorite;
 
     @NonNull
-    public CacheType cacheType;
-    public Long cachedDate;
+    private CacheType cacheType;
+    private Long cachedDate;
 
     public MealEntity(@NonNull String id,
                       String name,
@@ -56,4 +55,34 @@ public class MealEntity {
         this.cacheType = cacheType;
         this.cachedDate = cachedDate;
     }
+
+
+
+    @NonNull
+    public String getId() { return id; }
+
+    public String getName() { return name; }
+    public String getCategory() { return category; }
+    public String getArea() { return area; }
+    public String getInstructions() { return instructions; }
+    public String getThumbnailUrl() { return thumbnailUrl; }
+    public String getYoutubeUrl() { return youtubeUrl; }
+    public String getSourceUrl() { return sourceUrl; }
+    public List<MealIngredient> getIngredients() { return ingredients; }
+    public boolean isFavorite() { return isFavorite; }
+    @NonNull
+    public CacheType getCacheType() { return cacheType; }
+    public Long getCachedDate() { return cachedDate; }
+
+    public void setName(String name) { this.name = name; }
+    public void setCategory(String category) { this.category = category; }
+    public void setArea(String area) { this.area = area; }
+    public void setInstructions(String instructions) { this.instructions = instructions; }
+    public void setThumbnailUrl(String thumbnailUrl) { this.thumbnailUrl = thumbnailUrl; }
+    public void setYoutubeUrl(String youtubeUrl) { this.youtubeUrl = youtubeUrl; }
+    public void setSourceUrl(String sourceUrl) { this.sourceUrl = sourceUrl; }
+    public void setIngredients(List<MealIngredient> ingredients) { this.ingredients = ingredients; }
+    public void setFavorite(boolean favorite) { isFavorite = favorite; }
+    public void setCacheType(@NonNull CacheType cacheType) { this.cacheType = cacheType; }
+    public void setCachedDate(Long cachedDate) { this.cachedDate = cachedDate; }
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSource.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSource.java
@@ -21,5 +21,5 @@ public interface MealRemoteDataSource {
 
     Single<List<MealResponse>> getMealsByCountry(String country);
 
-    Single<Meal> getMealById(String id);
+    Single<MealResponse> getMealById(String id);
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSourceImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSourceImpl.java
@@ -6,11 +6,7 @@ import com.iti.mealmate.data.meal.model.mapper.MealMapper;
 import com.iti.mealmate.data.meal.model.response.MealOfTheDay;
 import com.iti.mealmate.data.meal.model.response.MealResponse;
 import com.iti.mealmate.data.meal.model.response.MealsBaseResponse;
-
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 
@@ -66,9 +62,8 @@ public class MealRemoteDataSourceImpl implements MealRemoteDataSource {
     }
 
     @Override
-    public Single<Meal> getMealById(String id) {
-        return mealApiService.getMealById(id)
-                .map(response -> MealMapper.toEntity(response.getMeals().get(0)));
+    public Single<MealResponse> getMealById(String id) {
+        return mealApiService.getMealById(id).map(response -> response.getMeals().get(0));
     }
 
 
@@ -106,11 +101,7 @@ public class MealRemoteDataSourceImpl implements MealRemoteDataSource {
 
     private Single<List<Meal>> fetchSuggestedMeals() {
         return Flowable.range(0, 10)
-                .flatMap(i ->
-                        mealApiService.getRandomMeal()
-                                .map(response -> MealMapper.toEntity(response.getMeals().get(0)))
-                                .toFlowable()
-                )
+                .flatMap(i -> fetchRandomMeal().toFlowable())
                 .toList()
                 .flatMap(meals -> {
                     if (meals.isEmpty()) {

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/mapper/MealMapper.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/mapper/MealMapper.java
@@ -1,5 +1,8 @@
 package com.iti.mealmate.data.meal.model.mapper;
 
+import com.iti.mealmate.core.util.DateUtils;
+import com.iti.mealmate.data.meal.datasource.local.entity.CacheType;
+import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
 import com.iti.mealmate.data.meal.model.entity.Meal;
 import com.iti.mealmate.data.meal.model.entity.MealIngredient;
 import com.iti.mealmate.data.meal.model.entity.MealLight;
@@ -66,4 +69,53 @@ public class MealMapper {
                 ))
                 .collect(Collectors.toList());
     }
+
+    public static List<Meal> cachedEntitiesToDomain(List<MealEntity> entities) {
+        if (entities == null || entities.isEmpty()) return List.of();
+        return entities.stream()
+                .map(MealMapper::cachedEntityToDomain)
+                .collect(Collectors.toList());
+    }
+
+    public static Meal cachedEntityToDomain(MealEntity entity) {
+        if (entity == null) return null;
+        return new Meal(
+                entity.getId(),
+                entity.getName(),
+                entity.getCategory(),
+                entity.getArea(),
+                entity.getInstructions(),
+                entity.getThumbnailUrl(),
+                entity.getYoutubeUrl(),
+                entity.getSourceUrl(),
+                entity.getIngredients(),
+                entity.isFavorite());
+    }
+
+    public static List<MealEntity> domainToCachedEntities(List<Meal> meals, CacheType type) {
+        if (meals == null || meals.isEmpty()) return List.of();
+        return meals.stream()
+                .map(meal -> MealMapper.domainToCachedEntity(meal, type))
+                .collect(Collectors.toList());
+    }
+
+    public static MealEntity domainToCachedEntity(Meal meal, CacheType type) {
+        if (meal == null)
+            return null;
+        return new MealEntity(
+                meal.getId(),
+                meal.getName(),
+                meal.getCategory(),
+                meal.getArea(),
+                meal.getInstructions(),
+                meal.getThumbnailUrl(),
+                meal.getYoutubeUrl(),
+                meal.getSourceUrl(),
+                meal.getIngredients(),
+                meal.isFavorite(),
+                type,
+                DateUtils.todayAtStartOfDay()
+        );
+    }
+
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepositoryImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepositoryImpl.java
@@ -3,12 +3,16 @@ package com.iti.mealmate.data.meal.repo;
 import com.iti.mealmate.core.error.AppErrorHandler;
 import com.iti.mealmate.core.network.AppConnectivityManager;
 import com.iti.mealmate.core.util.RxTask;
+import com.iti.mealmate.data.meal.datasource.local.datasource.favorite.FavoriteLocalDataSource;
+import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
 import com.iti.mealmate.data.meal.datasource.remote.MealRemoteDataSource;
 import com.iti.mealmate.data.meal.model.entity.Meal;
 import com.iti.mealmate.data.meal.model.entity.MealLight;
 import com.iti.mealmate.data.meal.model.mapper.MealMapper;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.reactivex.rxjava3.core.Single;
 
@@ -16,76 +20,107 @@ public class MealRepositoryImpl implements MealRepository {
 
     private final MealRemoteDataSource remoteDataSource;
     private final AppConnectivityManager connectivityManager;
+    private final FavoriteLocalDataSource favoriteLocalDataSource;
 
     public MealRepositoryImpl(MealRemoteDataSource remoteDataSource,
-                              AppConnectivityManager connectivityManager) {
+                              AppConnectivityManager connectivityManager,
+                              FavoriteLocalDataSource favoriteLocalDataSource) {
         this.remoteDataSource = remoteDataSource;
         this.connectivityManager = connectivityManager;
+        this.favoriteLocalDataSource = favoriteLocalDataSource;
     }
 
     @Override
     public Single<Meal> getMealOfTheDay() {
         return RxTask.withConnectivity(
-                remoteDataSource.getMealOfTheDay(),
-                connectivityManager
-        ).onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
+                        remoteDataSource.getMealOfTheDay(),
+                        connectivityManager
+                )
+                .flatMap(this::setFavoriteStatus)
+                .onErrorResumeNext(throwable ->
+                        Single.error(AppErrorHandler.handle(throwable)));
     }
 
     @Override
     public Single<List<MealLight>> getMealsByIngredient(String ingredient) {
         return RxTask.withConnectivity(
-                remoteDataSource.getMealsByIngredient(ingredient),
-                connectivityManager
-        )
-        .map(MealMapper::toLightList)
-        .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
+                        remoteDataSource.getMealsByIngredient(ingredient),
+                        connectivityManager
+                )
+                .map(MealMapper::toLightList)
+                .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
     }
 
     @Override
     public Single<List<Meal>> getSuggestedMeals() {
         return RxTask.withConnectivity(
-                remoteDataSource.getSuggestedMeals(),
-                connectivityManager
-        )
-        .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
+                        remoteDataSource.getSuggestedMeals(),
+                        connectivityManager)
+                .flatMap(this::setFavoriteStatusForList)
+                .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
     }
 
     @Override
     public Single<List<MealLight>> searchMealsByName(String name) {
         return RxTask.withConnectivity(
-                remoteDataSource.searchMealsByName(name),
-                connectivityManager
-        )
-        .map(MealMapper::toLightList)
-        .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
+                        remoteDataSource.searchMealsByName(name),
+                        connectivityManager
+                )
+                .map(MealMapper::toLightList)
+                .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
     }
 
     @Override
     public Single<List<MealLight>> getMealsByCategory(String category) {
         return RxTask.withConnectivity(
-                remoteDataSource.getMealsByCategory(category),
-                connectivityManager
-        )
-        .map(MealMapper::toLightList)
-        .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
+                        remoteDataSource.getMealsByCategory(category),
+                        connectivityManager
+                )
+                .map(MealMapper::toLightList)
+                .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
     }
 
     @Override
     public Single<List<MealLight>> getMealsByCountry(String country) {
         return RxTask.withConnectivity(
-                remoteDataSource.getMealsByCountry(country),
-                connectivityManager
-        )
-        .map(MealMapper::toLightList)
-        .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
+                        remoteDataSource.getMealsByCountry(country),
+                        connectivityManager
+                )
+                .map(MealMapper::toLightList)
+                .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
     }
 
     @Override
     public Single<Meal> getMealById(String id) {
         return RxTask.withConnectivity(
-                remoteDataSource.getMealById(id),
-                connectivityManager
-        )
-        .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
+                        remoteDataSource.getMealById(id),
+                        connectivityManager
+                )
+                .map(MealMapper::toEntity)
+                .flatMap(this::setFavoriteStatus)
+                .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
+    }
+
+    private Single<Meal> setFavoriteStatus(Meal meal) {
+        return favoriteLocalDataSource.isFavorite(meal.getId())
+                .map(isFavorite -> {
+                    meal.setFavorite(isFavorite);
+                    return meal;
+        });
+    }
+
+    private Single<List<Meal>> setFavoriteStatusForList(List<Meal> meals) {
+        return favoriteLocalDataSource.getUserFavorites()
+                .firstOrError()
+                .map(favoriteEntities -> {
+                    Set<String> favoriteIds = favoriteEntities.stream()
+                            .map(MealEntity::getId)
+                            .collect(Collectors.toSet());
+
+                    meals.forEach(meal ->
+                            meal.setFavorite(favoriteIds.contains(meal.getId())));
+
+                    return meals;
+                });
     }
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/favorite/FavoriteRepository.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/favorite/FavoriteRepository.java
@@ -1,0 +1,20 @@
+package com.iti.mealmate.data.meal.repo.favorite;
+
+import com.iti.mealmate.data.meal.model.entity.Meal;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+
+import java.util.List;
+
+public interface FavoriteRepository {
+
+    Flowable<List<Meal>> getAllFavoriteIds();
+
+    Single<Boolean> isFavorite(String mealId);
+
+    Completable addToFavorites(String mealId);
+
+    Completable removeFromFavorites(String mealId);
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/favorite/FavoriteRepositoryImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/favorite/FavoriteRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.iti.mealmate.data.meal.repo.favorite;
+
+
+import com.iti.mealmate.core.error.AppErrorHandler;
+import com.iti.mealmate.data.meal.datasource.local.datasource.favorite.FavoriteLocalDataSource;
+import com.iti.mealmate.data.meal.model.entity.Meal;
+import com.iti.mealmate.data.meal.model.mapper.MealMapper;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+
+import java.util.List;
+
+public class FavoriteRepositoryImpl implements FavoriteRepository {
+
+    private final FavoriteLocalDataSource favoriteLocalDataSource;
+
+    public FavoriteRepositoryImpl(FavoriteLocalDataSource favoriteLocalDataSource) {
+        this.favoriteLocalDataSource = favoriteLocalDataSource;
+    }
+
+    @Override
+    public Flowable<List<Meal>> getAllFavoriteIds() {
+        return favoriteLocalDataSource.getUserFavorites()
+                .map(MealMapper::cachedEntitiesToDomain)
+                .onErrorResumeNext(throwable -> Flowable.error(AppErrorHandler.handle(throwable)));
+    }
+
+    @Override
+    public Single<Boolean> isFavorite(String mealId) {
+        return favoriteLocalDataSource.isFavorite(mealId)
+                .onErrorResumeNext(throwable -> Single.error(AppErrorHandler.handle(throwable)));
+    }
+
+    @Override
+    public Completable addToFavorites(String mealId) {
+        return favoriteLocalDataSource.addToFavorites(mealId)
+                .onErrorResumeNext(throwable -> Completable.error(AppErrorHandler.handle(throwable)));
+
+    }
+
+    @Override
+    public Completable removeFromFavorites(String mealId) {
+        return favoriteLocalDataSource.removeFromFavorites(mealId)
+                .onErrorResumeNext(throwable -> Completable.error(AppErrorHandler.handle(throwable)));
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/di/ServiceLocator.java
+++ b/app/src/main/java/com/iti/mealmate/di/ServiceLocator.java
@@ -15,6 +15,8 @@ import com.iti.mealmate.data.auth.datasource.AuthDataSourceImpl;
 import com.iti.mealmate.data.auth.repo.AuthRepository;
 import com.iti.mealmate.data.auth.repo.AuthRepositoryImpl;
 import com.iti.mealmate.data.meal.api.MealApiService;
+import com.iti.mealmate.data.meal.datasource.local.datasource.favorite.FavoriteLocalDataSource;
+import com.iti.mealmate.data.meal.datasource.local.datasource.favorite.FavoriteLocalDataSourceImpl;
 import com.iti.mealmate.data.meal.datasource.remote.FirestoreMealHelper;
 import com.iti.mealmate.data.meal.datasource.remote.MealRemoteDataSource;
 import com.iti.mealmate.data.meal.datasource.remote.MealRemoteDataSourceImpl;
@@ -75,7 +77,9 @@ public final class ServiceLocator {
                 new FirestoreMealHelper(firestore);
         MealRemoteDataSource mealRemoteDataSource =
                 new MealRemoteDataSourceImpl(mealApiService, firestoreMealHelper);
-        mealRepository = new MealRepositoryImpl(mealRemoteDataSource, connectivityManager);
+        FavoriteLocalDataSource favoriteLocalDataSource =
+                new FavoriteLocalDataSourceImpl(appDatabase.mealDao());
+        mealRepository = new MealRepositoryImpl(mealRemoteDataSource, connectivityManager, favoriteLocalDataSource);
 
         FilterApiService filterApiService =
                 ApiClient.getInstance().create(FilterApiService.class);


### PR DESCRIPTION
- Implement `FavoriteLocalDataSource` and its implementation (`FavoriteLocalDataSourceImpl`) to manage favorite meals in the local database, providing methods to add, remove, retrieve, and check favorite status.
- Create `FavoriteRepository` and `FavoriteRepositoryImpl` to expose favorite-related operations to the domain layer, handling data source interactions and error mapping.
- Update `MealRepositoryImpl` to enrich fetched meal data by dynamically setting the `isFavorite` flag. This is achieved by cross-referencing with `FavoriteLocalDataSource`.
- Refactor `MealMapper` to include mappers for converting between `MealEntity` (cached) and `Meal` (domain) objects.
- Modify `ServiceLocator` to inject the new `FavoriteLocalDataSource` into `MealRepositoryImpl`.
- Update `MealEntity` to use private fields with public getters and setters for better encapsulation.
- Standardize the return type of `getMealById` in `MealRemoteDataSource` to `Single<MealResponse>`.