### PR TITLE
Implement local caching for "Meal of the Day" and "Suggested Meals" 💥✅

### DIFF
--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/dao/MealDao.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/dao/MealDao.java
@@ -26,6 +26,9 @@ public interface MealDao {
     @Query("SELECT * FROM meals WHERE cacheType = :type ORDER BY cachedDate DESC")
     Flowable<List<MealEntity>> getMealsByType(CacheType type);
 
+    @Query("SELECT * FROM meals WHERE cacheType = :type AND cachedDate = :todayStart ORDER BY id DESC")
+    Flowable<List<MealEntity>> getTodayMeals(CacheType type, long todayStart);
+
     @Query("SELECT * FROM meals WHERE isFavorite = 1")
     Flowable<List<MealEntity>> getFavorites();
 

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/meal/MealLocalDataSource.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/meal/MealLocalDataSource.java
@@ -1,6 +1,5 @@
 package com.iti.mealmate.data.meal.datasource.local.datasource.meal;
 
-import com.iti.mealmate.data.meal.datasource.local.entity.CacheType;
 import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
 
 import io.reactivex.rxjava3.core.Completable;
@@ -11,7 +10,7 @@ import java.util.List;
 public interface MealLocalDataSource {
     Completable insertMeals(List<MealEntity> meals);
     Completable insertMeal(MealEntity meal);
-    Flowable<MealEntity> getMealById(String mealId);
-    Flowable<List<MealEntity>> getMealsByType(CacheType type);
+    Flowable<List<MealEntity>> getDailyMeal();
+    Flowable<List<MealEntity>> getSuggestedMeals();
     Single<Boolean> isMealExists(String mealId);
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/meal/MealLocalDataSourceImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/meal/MealLocalDataSourceImpl.java
@@ -1,5 +1,7 @@
 package com.iti.mealmate.data.meal.datasource.local.datasource.meal;
 
+
+import com.iti.mealmate.core.util.DateUtils;
 import com.iti.mealmate.data.meal.datasource.local.dao.MealDao;
 import com.iti.mealmate.data.meal.datasource.local.entity.CacheType;
 import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
@@ -7,6 +9,7 @@ import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
+
 import java.util.List;
 
 public class MealLocalDataSourceImpl implements MealLocalDataSource {
@@ -27,14 +30,15 @@ public class MealLocalDataSourceImpl implements MealLocalDataSource {
         return mealDao.insertMeal(meal);
     }
 
+
     @Override
-    public Flowable<MealEntity> getMealById(String mealId) {
-        return mealDao.getMealById(mealId);
+    public Flowable<List<MealEntity>> getDailyMeal() {
+        return mealDao.getTodayMeals(CacheType.DAILY, DateUtils.todayAtStartOfDay());
     }
 
     @Override
-    public Flowable<List<MealEntity>> getMealsByType(CacheType type) {
-        return mealDao.getMealsByType(type);
+    public Flowable<List<MealEntity>> getSuggestedMeals() {
+        return mealDao.getTodayMeals(CacheType.TRENDING, DateUtils.todayAtStartOfDay());
     }
 
     @Override

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSourceImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/remote/MealRemoteDataSourceImpl.java
@@ -21,11 +21,15 @@ public class MealRemoteDataSourceImpl implements MealRemoteDataSource {
         this.firestoreMealHelper = firestoreMealHelper;
     }
 
+    private static final String TAG = "MEALDATASOURCE";
+
     @Override
     public Single<Meal> getMealOfTheDay() {
+
         return firestoreMealHelper.getMealOfTheDay()
                 .map(MealOfTheDay::getDailyMeal)
                 .onErrorResumeNext(e -> getOrFetchDailyMeals().map(MealOfTheDay::getDailyMeal));
+
     }
 
     @Override
@@ -35,6 +39,7 @@ public class MealRemoteDataSourceImpl implements MealRemoteDataSource {
                 .onErrorResumeNext(e -> getOrFetchDailyMeals()
                         .map(MealOfTheDay::getSuggestedMeals)
                 );
+
     }
 
     @Override

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepository.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/MealRepository.java
@@ -5,15 +5,16 @@ import com.iti.mealmate.data.meal.model.entity.MealLight;
 
 import java.util.List;
 
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 
 public interface MealRepository {
 
-    Single<Meal> getMealOfTheDay();
+    Flowable<Meal> getMealOfTheDay();
 
     Single<List<MealLight>> getMealsByIngredient(String ingredient);
 
-    Single<List<Meal>>  getSuggestedMeals();
+    Flowable<List<Meal>>  getSuggestedMeals();
 
     Single<List<MealLight>> searchMealsByName(String name);
 

--- a/app/src/main/java/com/iti/mealmate/di/ServiceLocator.java
+++ b/app/src/main/java/com/iti/mealmate/di/ServiceLocator.java
@@ -86,7 +86,7 @@ public final class ServiceLocator {
         FavoriteLocalDataSource favoriteLocalDataSource =
                 new FavoriteLocalDataSourceImpl(appDatabase.mealDao());
         mealLocalDataSource = new MealLocalDataSourceImpl(appDatabase.mealDao());
-        mealRepository = new MealRepositoryImpl(mealRemoteDataSource, connectivityManager, favoriteLocalDataSource);
+        mealRepository = new MealRepositoryImpl(mealRemoteDataSource, connectivityManager, favoriteLocalDataSource, mealLocalDataSource);
         favoriteRepository = new FavoriteRepositoryImpl(favoriteLocalDataSource, mealLocalDataSource);
 
         FilterApiService filterApiService =

--- a/app/src/main/java/com/iti/mealmate/ui/home/view/HomeFragment.java
+++ b/app/src/main/java/com/iti/mealmate/ui/home/view/HomeFragment.java
@@ -1,7 +1,6 @@
 package com.iti.mealmate.ui.home.view;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -127,17 +126,7 @@ public class HomeFragment extends Fragment implements HomeView {
         ActivityExtensions.showErrorSnackBar(requireActivity(), message);
     }
 
-    private static final String TAG = "HomeFragment";
 
-    @Override
-    public void onHiddenChanged(boolean hidden) {
-        super.onHiddenChanged(hidden);
-
-        Log.d(TAG, "onHiddenChanged: ");
-        if (!hidden) {
-            presenter.loadHomeData();
-        }
-    }
     @Override
     public void onDestroyView() {
         super.onDestroyView();


### PR DESCRIPTION
- Update `MealDao` to support querying meals by `CacheType` and specific date timestamps.
- Refactor `MealLocalDataSource` to provide dedicated methods for retrieving daily and suggested meals using the current day's start time.
- Modify `MealRepository` and its implementation to return `Flowable` instead of `Single` for home screen data, implementing a "local-first" cache strategy.
- Integrate caching logic in `MealRepositoryImpl` to fetch from remote and update Room only when local data for the current day is missing.
- Update `HomePresenterImpl` to handle `Flowable` zip streams and prevent redundant data reloads if data is already present.
- Refine `HomeFragment` by removing manual refresh logic in `onHiddenChanged`, relying instead on the reactive repository layer.
- Update `ServiceLocator` to properly inject `MealLocalDataSource` into the `MealRepository`.