### PR TITLE
Implement meal planning data layer with Room and RxJava 3 ✅

### DIFF
--- a/app/src/main/java/com/iti/mealmate/core/util/DateUtils.java
+++ b/app/src/main/java/com/iti/mealmate/core/util/DateUtils.java
@@ -1,5 +1,6 @@
 package com.iti.mealmate.core.util;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 
@@ -13,5 +14,12 @@ public final class DateUtils {
                 .atStartOfDay(ZoneId.systemDefault())
                 .toInstant()
                 .toEpochMilli();
+
+    }
+
+    public static LocalDate timestampToLocalDate(long timestamp) {
+        return Instant.ofEpochMilli(timestamp)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();
     }
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/dao/PlanDao.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/dao/PlanDao.java
@@ -5,10 +5,13 @@ import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 import androidx.room.Transaction;
-import com.iti.mealmate.data.meal.datasource.local.entity.MealEntity;
+
 import com.iti.mealmate.data.meal.datasource.local.entity.PlannedMealsEntity;
+import com.iti.mealmate.data.meal.datasource.local.entity.PlannedMealDetailEntity;
+
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+
 import java.util.List;
 
 @Dao
@@ -17,23 +20,17 @@ public interface PlanDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     Completable addToPlan(PlannedMealsEntity plan);
 
-    @Transaction
-    @Query("SELECT m.* FROM meals m " +
-            "INNER JOIN planned_meals p ON m.id = p.mealId " +
-            "WHERE p.weekStartDate = :weekStart " +
-            "ORDER BY CASE p.dayName " +
-            "WHEN 'MONDAY' THEN 1 " +
-            "WHEN 'TUESDAY' THEN 2 " +
-            "WHEN 'WEDNESDAY' THEN 3 " +
-            "WHEN 'THURSDAY' THEN 4 " +
-            "WHEN 'FRIDAY' THEN 5 " +
-            "WHEN 'SATURDAY' THEN 6 " +
-            "WHEN 'SUNDAY' THEN 7 END")
-    Flowable<List<MealEntity>> getPlannedMealsForWeek(String weekStart);
-
-    @Query("DELETE FROM planned_meals WHERE weekStartDate = :weekStart AND dayName = :dayName")
-    Completable removeFromPlan(String weekStart, String dayName);
+    @Query("DELETE FROM planned_meals WHERE mealId = :mealId AND plannedDate = :plannedDate")
+    Completable removeMealFromDay(String mealId, long plannedDate);
 
     @Query("DELETE FROM planned_meals")
     Completable clearAllPlans();
+
+    @Transaction
+    @Query("SELECT * FROM planned_meals WHERE plannedDate = :plannedDate")
+    Flowable<List<PlannedMealDetailEntity>> getPlannedMealsWithDetails(long plannedDate);
+
+    @Transaction
+    @Query("SELECT * FROM planned_meals WHERE plannedDate BETWEEN :startDate AND :endDate")
+    Flowable<List<PlannedMealDetailEntity>> getPlannedMealsWithDetailsForRange(long startDate, long endDate);
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/plan/PlanLocalDataSource.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/plan/PlanLocalDataSource.java
@@ -1,0 +1,23 @@
+package com.iti.mealmate.data.meal.datasource.local.datasource.plan;
+
+import com.iti.mealmate.data.meal.datasource.local.entity.PlannedMealDetailEntity;
+import com.iti.mealmate.data.meal.model.entity.Meal;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface PlanLocalDataSource {
+
+    Completable addMealToPlan(Meal meal, LocalDate date);
+
+    Completable removeMealFromDay(String mealId, LocalDate date);
+
+    Completable clearAllPlans();
+
+    Flowable<List<PlannedMealDetailEntity>> getMealsForDay(LocalDate date);
+
+    Flowable<List<PlannedMealDetailEntity>> getMealsForDateRange(LocalDate startDate, LocalDate endDate);
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/plan/PlanLocalDataSourceImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/datasource/plan/PlanLocalDataSourceImpl.java
@@ -1,0 +1,53 @@
+package com.iti.mealmate.data.meal.datasource.local.datasource.plan;
+
+import com.iti.mealmate.data.meal.datasource.local.dao.PlanDao;
+import com.iti.mealmate.data.meal.datasource.local.entity.PlannedMealDetailEntity;
+import com.iti.mealmate.data.meal.datasource.local.entity.PlannedMealsEntity;
+import com.iti.mealmate.data.meal.model.entity.Meal;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+public class PlanLocalDataSourceImpl implements PlanLocalDataSource {
+
+    private final PlanDao planDao;
+
+    public PlanLocalDataSourceImpl(PlanDao planDao) {
+        this.planDao = planDao;
+    }
+
+    @Override
+    public Completable addMealToPlan(Meal meal, LocalDate date) {
+        long plannedDateMillis = date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        PlannedMealsEntity entity = new PlannedMealsEntity(meal.getId(), plannedDateMillis);
+        return planDao.addToPlan(entity);
+    }
+
+    @Override
+    public Completable removeMealFromDay(String mealId, LocalDate date) {
+        long plannedDateMillis = date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        return planDao.removeMealFromDay(mealId, plannedDateMillis);
+    }
+
+    @Override
+    public Completable clearAllPlans() {
+        return planDao.clearAllPlans();
+    }
+
+    @Override
+    public Flowable<List<PlannedMealDetailEntity>> getMealsForDay(LocalDate date) {
+        long plannedDateMillis = date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        return planDao.getPlannedMealsWithDetails(plannedDateMillis);
+    }
+
+    @Override
+    public Flowable<List<PlannedMealDetailEntity>> getMealsForDateRange(LocalDate startDate, LocalDate endDate) {
+        long startMillis = startDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        long endMillis = endDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        return planDao.getPlannedMealsWithDetailsForRange(startMillis, endMillis);
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/PlannedMealDetailEntity.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/PlannedMealDetailEntity.java
@@ -1,0 +1,35 @@
+package com.iti.mealmate.data.meal.datasource.local.entity;
+
+import androidx.room.Embedded;
+import androidx.room.Relation;
+
+import java.io.Serializable;
+
+public class PlannedMealDetailEntity implements Serializable {
+
+    @Embedded
+    private PlannedMealsEntity plannedMeal;
+
+    @Relation(
+            parentColumn = "mealId",
+            entityColumn = "id"
+    )
+    private MealEntity meal;
+
+
+    public PlannedMealsEntity getPlannedMeal() {
+        return plannedMeal;
+    }
+
+    public void setPlannedMeal(PlannedMealsEntity plannedMeal) {
+        this.plannedMeal = plannedMeal;
+    }
+
+    public MealEntity getMeal() {
+        return meal;
+    }
+
+    public void setMeal(MealEntity meal) {
+        this.meal = meal;
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/PlannedMealsEntity.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/datasource/local/entity/PlannedMealsEntity.java
@@ -7,11 +7,10 @@ import androidx.room.Index;
 
 @Entity(
         tableName = "planned_meals",
-        primaryKeys = {"mealId", "weekStartDate", "dayName"},
+        primaryKeys = {"mealId", "plannedDate"},
         indices = {
                 @Index("mealId"),
-                @Index("weekStartDate"),
-                @Index(value = {"weekStartDate", "dayName"})
+                @Index("plannedDate"),
         },
         foreignKeys = {
                 @ForeignKey(
@@ -25,21 +24,29 @@ import androidx.room.Index;
 public class PlannedMealsEntity {
 
     @NonNull
-    public String mealId;
+    private  String mealId;
 
-    @NonNull
-    public String dayName;
+    private long plannedDate;
 
-    @NonNull
-    public String weekStartDate;
-
-    public Long plannedDate;
-
-    public PlannedMealsEntity(@NonNull String mealId, @NonNull String dayName,
-                              @NonNull String weekStartDate, Long plannedDate) {
+    public PlannedMealsEntity(@NonNull String mealId, long plannedDate) {
         this.mealId = mealId;
-        this.dayName = dayName;
-        this.weekStartDate = weekStartDate;
+        this.plannedDate = plannedDate;
+    }
+
+    @NonNull
+    public String getMealId() {
+        return mealId;
+    }
+
+    public void setMealId(@NonNull String mealId) {
+        this.mealId = mealId;
+    }
+
+    public long getPlannedDate() {
+        return plannedDate;
+    }
+
+    public void setPlannedDate(long plannedDate) {
         this.plannedDate = plannedDate;
     }
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/entity/PlannedMeal.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/entity/PlannedMeal.java
@@ -1,0 +1,32 @@
+package com.iti.mealmate.data.meal.model.entity;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+public class PlannedMeal {
+
+    private Meal meal;
+    private LocalDate plannedDate;
+
+    public PlannedMeal(Meal meal, LocalDate plannedDate) {
+        this.meal = meal;
+        this.plannedDate = plannedDate;
+    }
+
+    public Meal getMeal() {
+        return meal;
+    }
+
+    public LocalDate getPlannedDate() {
+        return plannedDate;
+    }
+
+
+    public void setMeal(Meal meal) {
+        this.meal = meal;
+    }
+
+    public void setPlannedDate(LocalDate plannedDate) {
+        this.plannedDate = plannedDate;
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/mapper/PlanMapper.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/mapper/PlanMapper.java
@@ -1,0 +1,32 @@
+package com.iti.mealmate.data.meal.model.mapper;
+
+import com.iti.mealmate.core.util.DateUtils;
+import com.iti.mealmate.data.meal.datasource.local.entity.PlannedMealDetailEntity;
+import com.iti.mealmate.data.meal.model.entity.PlannedMeal;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PlanMapper {
+
+    private PlanMapper(){}
+
+
+    public static PlannedMeal toDomainEntity(PlannedMealDetailEntity mealDetailEntity){
+
+        return new PlannedMeal(
+                MealMapper.cachedEntityToDomain(mealDetailEntity.getMeal()),
+                DateUtils.timestampToLocalDate(mealDetailEntity.getPlannedMeal().getPlannedDate())
+        );
+    }
+
+    public static List<PlannedMeal> toDomainEntityList(List<PlannedMealDetailEntity> mealDetailEntities){
+
+        return mealDetailEntities
+                .stream()
+                .map(PlanMapper::toDomainEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/plan/PlanRepository.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/plan/PlanRepository.java
@@ -1,0 +1,23 @@
+package com.iti.mealmate.data.meal.repo.plan;
+
+import com.iti.mealmate.data.meal.model.entity.PlannedMeal;
+import com.iti.mealmate.data.meal.model.entity.Meal;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface PlanRepository {
+
+    Completable addPlannedMeal(Meal meal, LocalDate date);
+
+    Completable removePlannedMealFromDay(String mealId, LocalDate date);
+
+    Completable clearAllPlans();
+
+    Flowable<List<PlannedMeal>> getPlannedMealsForDay(LocalDate date);
+
+    Flowable<List<PlannedMeal>> getPlannedMealsForNextTwoWeeks();
+}

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/plan/PlanRepositoryImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/plan/PlanRepositoryImpl.java
@@ -1,0 +1,76 @@
+package com.iti.mealmate.data.meal.repo.plan;
+
+import com.iti.mealmate.core.error.AppErrorHandler;
+import com.iti.mealmate.data.meal.datasource.local.datasource.meal.MealLocalDataSource;
+import com.iti.mealmate.data.meal.datasource.local.datasource.plan.PlanLocalDataSourceImpl;
+import com.iti.mealmate.data.meal.datasource.local.entity.CacheType;
+import com.iti.mealmate.data.meal.model.entity.Meal;
+import com.iti.mealmate.data.meal.model.entity.PlannedMeal;
+import com.iti.mealmate.data.meal.model.mapper.MealMapper;
+import com.iti.mealmate.data.meal.model.mapper.PlanMapper;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+
+public class PlanRepositoryImpl implements PlanRepository{
+    private final PlanLocalDataSourceImpl planLocalDataSource;
+    private final MealLocalDataSource mealLocalDataSource;
+
+    public PlanRepositoryImpl(PlanLocalDataSourceImpl planLocalDataSource, MealLocalDataSource mealLocalDataSource) {
+        this.planLocalDataSource = planLocalDataSource;
+        this.mealLocalDataSource = mealLocalDataSource;
+    }
+
+    @Override
+    public Completable addPlannedMeal(Meal meal, LocalDate date) {
+        return mealLocalDataSource.isMealExists(meal.getId())
+                .flatMapCompletable(isExists -> {
+                    if (isExists) {
+                        return planLocalDataSource.addMealToPlan(meal, date);
+                    } else {
+                        return mealLocalDataSource
+                                .insertMeal(MealMapper.domainToCachedEntity(meal, CacheType.NONE))
+                                .andThen(planLocalDataSource.addMealToPlan(meal, date));
+                    }
+                }).onErrorResumeNext(throwable ->
+                        Completable.error(AppErrorHandler.handle(throwable)));
+    }
+
+
+    @Override
+    public Completable removePlannedMealFromDay(String mealId, LocalDate date) {
+        return planLocalDataSource.removeMealFromDay(mealId, date)
+                .onErrorResumeNext(throwable ->
+                        Completable.error(AppErrorHandler.handle(throwable)));
+    }
+
+    @Override
+    public Completable clearAllPlans() {
+        return planLocalDataSource.clearAllPlans()
+                .onErrorResumeNext(throwable ->
+                        Completable.error(AppErrorHandler.handle(throwable)));
+    }
+
+    @Override
+    public Flowable<List<PlannedMeal>> getPlannedMealsForDay(LocalDate date) {
+        return planLocalDataSource
+                .getMealsForDay(date)
+                .map(PlanMapper::toDomainEntityList)
+                .onErrorResumeNext(throwable -> Flowable.error(AppErrorHandler.handle(throwable)));
+    }
+
+    @Override
+    public Flowable<List<PlannedMeal>> getPlannedMealsForNextTwoWeeks() {
+        LocalDate startOfWeek = LocalDate.now().with(DayOfWeek.SATURDAY);
+        LocalDate endDate = startOfWeek.plusWeeks(2);
+
+        return planLocalDataSource
+                .getMealsForDateRange(startOfWeek, endDate)
+                .map(PlanMapper::toDomainEntityList)
+                .onErrorResumeNext(throwable -> Flowable.error(AppErrorHandler.handle(throwable)));
+    }
+}


### PR DESCRIPTION
- Implement `PlanRepository` and `PlanRepositoryImpl` to manage meal plan logic, including adding meals with persistence checks, removing meals, and fetching plans for specific days or a two-week range.
- Implement `PlanLocalDataSource` and its implementation to handle Room database operations, converting `LocalDate` to epoch milliseconds for storage.
- Update `PlanDao` with new queries for deleting specific meal-date entries and fetching planned meals with details using `@Relation`.
- Create `PlannedMealDetailEntity` to facilitate Room's relational mapping between `PlannedMealsEntity` and `MealEntity`.
- Refactor `PlannedMealsEntity` to use a composite primary key of `mealId` and `plannedDate`, simplifying the schema from week/day-based tracking to timestamp-based tracking.
- Create `PlanMapper` to handle transformations between local database entities and domain models.
- Enhance `DateUtils` with `timestampToLocalDate` and `localDateToTimestamp` helper methods for consistent date conversion.
- Define the `PlannedMeal` domain model to represent a scheduled meal.