### PR TITLE
Implement a reusable confirmation dialog and integrate it into the Favorites and Plan features 🔥✅

### DIFF
--- a/app/src/main/java/com/iti/mealmate/ui/common/DialogUtils.java
+++ b/app/src/main/java/com/iti/mealmate/ui/common/DialogUtils.java
@@ -1,0 +1,93 @@
+package com.iti.mealmate.ui.common;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.animation.DecelerateInterpolator;
+
+import androidx.annotation.NonNull;
+import androidx.cardview.widget.CardView;
+import com.iti.mealmate.databinding.DialogConfirmationBinding;
+
+import java.util.function.Consumer;
+
+public class DialogUtils {
+
+    private DialogUtils() {}
+
+    public static void showConfirmationDialog(
+            @NonNull Context context,
+            @NonNull String title,
+            @NonNull String message,
+            @NonNull Consumer<Void> onConfirm
+    ) {
+        DialogConfirmationBinding binding = DialogConfirmationBinding.inflate(
+                LayoutInflater.from(context)
+        );
+
+        Dialog dialog = createDialog(context, binding);
+        setupDialogContent(binding, title, message);
+        setupDialogActions(binding, dialog, onConfirm);
+
+        dialog.show();
+        animateDialogEntry(binding.dialogCard);
+    }
+
+    private static Dialog createDialog(Context context, DialogConfirmationBinding binding) {
+        Dialog dialog = new Dialog(context);
+        dialog.setContentView(binding.getRoot());
+        dialog.setCancelable(true);
+        configureDialogWindow(dialog.getWindow());
+        return dialog;
+    }
+
+    private static void configureDialogWindow(Window window) {
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            window.setLayout(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            );
+        }
+    }
+
+    private static void setupDialogContent(
+            DialogConfirmationBinding binding,
+            String title,
+            String message
+    ) {
+        binding.textDialogTitle.setText(title);
+        binding.textDialogMessage.setText(message);
+    }
+
+    private static void setupDialogActions(
+            DialogConfirmationBinding binding,
+            Dialog dialog,
+            Consumer<Void> onConfirm
+    ) {
+        binding.btnSure.setOnClickListener(v -> {
+            onConfirm.accept(null);
+            dialog.dismiss();
+        });
+
+        binding.btnCancel.setOnClickListener(v -> dialog.dismiss());
+    }
+
+    private static void animateDialogEntry(CardView card) {
+        card.setScaleX(0.8f);
+        card.setScaleY(0.8f);
+        card.setAlpha(0f);
+
+        card.animate()
+                .scaleX(1f)
+                .scaleY(1f)
+                .alpha(1f)
+                .setDuration(200)
+                .setInterpolator(new DecelerateInterpolator())
+                .start();
+    }
+}

--- a/app/src/main/java/com/iti/mealmate/ui/favorites/FavoritePresenter.java
+++ b/app/src/main/java/com/iti/mealmate/ui/favorites/FavoritePresenter.java
@@ -5,5 +5,5 @@ import com.iti.mealmate.data.meal.model.entity.Meal;
 
 public interface FavoritePresenter extends BasePresenter {
     void loadFavorites();
-    void toggleFavorite(Meal meal);
+    void removeFavorite(Meal meal);
 }

--- a/app/src/main/java/com/iti/mealmate/ui/favorites/presenter/FavoritePresenterImpl.java
+++ b/app/src/main/java/com/iti/mealmate/ui/favorites/presenter/FavoritePresenterImpl.java
@@ -49,31 +49,27 @@ public class FavoritePresenterImpl implements FavoritePresenter {
     }
 
     @Override
-    public void toggleFavorite(Meal meal) {
-        boolean previousStatus = meal.isFavorite();
-        Completable action = previousStatus
-                ? favoriteRepository.removeFromFavorites(meal)
-                : favoriteRepository.addToFavorites(meal);
-
-        disposables.add(action
+    public void removeFavorite(Meal meal) {
+        disposables.add(favoriteRepository.removeFromFavorites(meal)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
-                        () -> onFavoriteToggled(meal, !previousStatus),
-                        throwable -> {
-                            meal.setFavorite(previousStatus);
-                            loadFavorites();
-                            view.showErrorMessage(throwable.getMessage());
-                        }
+                        () -> onFavoriteRemoved(meal),
+                        throwable -> onFavoriteRemoveError(meal, throwable)
                 ));
     }
 
-    private void onFavoriteToggled(Meal meal, boolean isFavorite) {
-        meal.setFavorite(isFavorite);
-        view.showSuccessMessage(isFavorite ? "Added to favorites" : "Removed from favorites");
+    private void onFavoriteRemoved(Meal meal) {
+        meal.setFavorite(false);
+        view.showSuccessMessage("Removed from favorites");
         loadFavorites();
     }
 
+    private void onFavoriteRemoveError(Meal meal, Throwable throwable) {
+        meal.setFavorite(true);
+        loadFavorites();
+        view.showErrorMessage(throwable.getMessage());
+    }
 
     @Override
     public void onDestroy() {

--- a/app/src/main/java/com/iti/mealmate/ui/favorites/view/FavoritesFragment.java
+++ b/app/src/main/java/com/iti/mealmate/ui/favorites/view/FavoritesFragment.java
@@ -14,6 +14,7 @@ import com.iti.mealmate.data.meal.model.entity.Meal;
 import com.iti.mealmate.databinding.FragmentFavoritesBinding;
 import com.iti.mealmate.di.ServiceLocator;
 import com.iti.mealmate.ui.common.ActivityExtensions;
+import com.iti.mealmate.ui.common.DialogUtils;
 import com.iti.mealmate.ui.favorites.FavoritePresenter;
 import com.iti.mealmate.ui.favorites.FavoriteView;
 import com.iti.mealmate.ui.favorites.presenter.FavoritePresenterImpl;
@@ -56,7 +57,12 @@ public class FavoritesFragment extends Fragment implements FavoriteView {
     }
 
     private void showDeleteConfirmation(Meal meal) {
-        presenter.toggleFavorite(meal);
+        DialogUtils.showConfirmationDialog(
+                requireContext(),
+                getString(R.string.remove_favorite_title),
+                getString(R.string.remove_favorite_message),
+                v -> presenter.removeFavorite(meal)
+        );
     }
 
     @Override

--- a/app/src/main/java/com/iti/mealmate/ui/plan/view/PlanFragment.java
+++ b/app/src/main/java/com/iti/mealmate/ui/plan/view/PlanFragment.java
@@ -1,6 +1,5 @@
 package com.iti.mealmate.ui.plan.view;
 
-import android.graphics.Typeface;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -20,6 +19,7 @@ import com.iti.mealmate.data.meal.model.entity.PlannedMeal;
 import com.iti.mealmate.databinding.FragmentPlanBinding;
 import com.iti.mealmate.di.ServiceLocator;
 import com.iti.mealmate.ui.common.ActivityExtensions;
+import com.iti.mealmate.ui.common.DialogUtils;
 import com.iti.mealmate.ui.mealdetail.view.MealDetailsActivity;
 import com.iti.mealmate.ui.meallist.view.MealListActivity;
 import com.iti.mealmate.ui.plan.PlanPresenter;
@@ -62,10 +62,19 @@ public class PlanFragment extends Fragment implements PlanView {
     }
 
     private void setupRecyclerView() {
-        plansAdapter = new PlansAdapter(presenter::removeMeal, this::navigateToMealDetails);
+        plansAdapter = new PlansAdapter(this::showConfirmationDialog, this::navigateToMealDetails);
         binding.recyclerPlan.setLayoutManager(new LinearLayoutManager(requireContext()));
         binding.recyclerPlan.setAdapter(plansAdapter);
         binding.recyclerPlan.setHasFixedSize(false);
+    }
+
+    private void showConfirmationDialog(PlannedMeal meal) {
+        DialogUtils.showConfirmationDialog(
+                requireContext(),
+                getString(R.string.remove_plan_title),
+                getString(R.string.remove_plan_message),
+                v -> presenter.removeMeal(meal)
+        );
     }
 
     private void navigateToMealDetails(PlannedMeal meal) {

--- a/app/src/main/res/layout/dialog_confirmation.xml
+++ b/app/src/main/res/layout/dialog_confirmation.xml
@@ -1,10 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/dialog_card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="24dp"
+    app:cardUseCompatPadding="true"
     app:cardBackgroundColor="@color/colorSurface"
     app:cardCornerRadius="20dp"
     app:cardElevation="8dp"
@@ -89,4 +90,4 @@
             app:layout_constraintTop_toTopOf="@+id/btn_cancel" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</com.google.android.material.card.MaterialCardView>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,4 +137,11 @@
 
     <string name="placeholder_date_range">Oct 23 - Oct 29</string>
     <string name="placeholder_day">Monday</string>
+
+    <string name="remove_plan_title">Remove Meal</string>
+    <string name="remove_plan_message">Are you sure you want to remove this meal from your plan?</string>
+
+    <string name="remove_favorite_title">Remove Favorite</string>
+    <string name="remove_favorite_message">Are you sure you want to remove this meal from your favorites?</string>
+
 </resources>


### PR DESCRIPTION
- Create `DialogUtils` to handle the creation and animated display of a custom confirmation dialog using View Binding.
- Implement `dialog_confirmation.xml` and add corresponding string resources for removal confirmation messages.
- Integrate the confirmation dialog into `PlanFragment` before removing a meal from the weekly plan.
- Integrate the confirmation dialog into `FavoritesFragment` before removing a meal from favorites.
- Refactor `FavoritePresenter` and `FavoritePresenterImpl` to replace the generic `toggleFavorite` method with a specific `removeFavorite` implementation.
- Improve error handling and state synchronization in `FavoritePresenterImpl` when a removal action fails.
- Add entry animations (scale and alpha) to the confirmation dialog for a smoother user experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI and presenter-behavior changes around destructive actions; risk is mainly regressions in removal flows and state consistency when repository calls fail.
> 
> **Overview**
> Adds a reusable `DialogUtils.showConfirmationDialog` (with view-binding and a small entry animation) backed by an updated `dialog_confirmation.xml` and new removal-specific string resources.
> 
> Integrates the confirmation step before deleting items in `FavoritesFragment` (removing a favorite) and `PlanFragment` (removing a planned meal), and refactors the favorites presenter API from `toggleFavorite` to a dedicated `removeFavorite` with clearer success/error state synchronization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c26c1f43f7fa7b01e30de2b8c7123b78f0e3b53b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->