### PR TITLE
fix(meal-plan): correct date range calculation for weekly meal plans ✅

### DIFF
--- a/app/src/main/java/com/iti/mealmate/core/util/DateUtils.java
+++ b/app/src/main/java/com/iti/mealmate/core/util/DateUtils.java
@@ -35,16 +35,19 @@ public final class DateUtils {
     }
 
 
-    public static LocalDate endOfNextWeek() {
+    public static LocalDate startOfCurrentWeek() {
         LocalDate today = LocalDate.now();
-        int daysUntilNextSaturday = DayOfWeek.SATURDAY.getValue() - today.getDayOfWeek().getValue();
-        if (daysUntilNextSaturday <= 0) {
-            daysUntilNextSaturday += 7;
+        LocalDate saturday = today.with(DayOfWeek.SATURDAY);
+
+        if (today.getDayOfWeek().getValue() < DayOfWeek.SATURDAY.getValue()) {
+            saturday = saturday.minusWeeks(1);
         }
 
-        LocalDate nextSaturday = today.plusDays(daysUntilNextSaturday);
+        return saturday;
+    }
 
-        return nextSaturday.plusDays(6);
+    public static LocalDate endOfNextWeek() {
+        return startOfCurrentWeek().plusDays(13);
     }
 
     public static long endOfNextWeekMillis() {

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/plan/PlanRepositoryImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/plan/PlanRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.iti.mealmate.data.meal.repo.plan;
 
 import com.iti.mealmate.core.error.AppErrorHandler;
+import com.iti.mealmate.core.util.DateUtils;
 import com.iti.mealmate.data.meal.datasource.local.datasource.meal.MealLocalDataSource;
 import com.iti.mealmate.data.meal.datasource.local.datasource.plan.PlanLocalDataSource;
 import com.iti.mealmate.data.meal.datasource.local.datasource.plan.PlanLocalDataSourceImpl;
@@ -10,7 +11,6 @@ import com.iti.mealmate.data.meal.model.entity.PlannedMeal;
 import com.iti.mealmate.data.meal.model.mapper.MealMapper;
 import com.iti.mealmate.data.meal.model.mapper.PlanMapper;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -70,11 +70,8 @@ public class PlanRepositoryImpl implements PlanRepository {
 
     @Override
     public Flowable<List<DayPlan>> getPlannedMealsForNextTwoWeeks() {
-        LocalDate startOfWeek = LocalDate.now().with(DayOfWeek.SATURDAY);
-        LocalDate endDate = startOfWeek.plusWeeks(2);
-
         return planLocalDataSource
-                .getMealsForDateRange(startOfWeek, endDate)
+                .getMealsForDateRange(DateUtils.startOfCurrentWeek(), DateUtils.endOfNextWeek())
                 .map(PlanMapper::groupByDay)
                 .onErrorResumeNext(throwable ->
                         Flowable.error(AppErrorHandler.handle(throwable)));


### PR DESCRIPTION
- Define start of week as the most recent Saturday via DateUtils.startOfCurrentWeek()
- Rework endOfNextWeek() to calculate range relative to current week start
- Update PlanRepositoryImpl to use centralized DateUtils logic for a consistent two-week window