### PR TITLE
Fix bugs and add UI/loading improvements for Plan and Favorites 🔥✅

### DIFF
--- a/app/src/main/java/com/iti/mealmate/data/meal/model/entity/DayPlan.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/entity/DayPlan.java
@@ -1,23 +1,35 @@
 package com.iti.mealmate.data.meal.model.entity;
 
+import com.google.firebase.firestore.Exclude;
+
 import java.time.LocalDate;
 import java.util.List;
-
 public class DayPlan {
 
-    private LocalDate date;
+    private String date;
     private List<PlannedMeal> meals;
+
+    public DayPlan() {}
+
     public DayPlan(LocalDate date, List<PlannedMeal> meals) {
-        this.date = date;
+        this.date = date.toString();
         this.meals = meals;
     }
 
-    public LocalDate getDate() {
+    public String getDate() {
         return date;
     }
 
-    public void setDate(LocalDate date) {
+    public void setDate(String date) {
         this.date = date;
+    }
+    @Exclude
+    public LocalDate getLocalDate() {
+        return date != null ? LocalDate.parse(date) : null;
+    }
+
+    public void setLocalDate(LocalDate date) {
+        this.date = date != null ? date.toString() : null;
     }
 
     public List<PlannedMeal> getMeals() {
@@ -28,8 +40,9 @@ public class DayPlan {
         this.meals = meals;
     }
 
-    public boolean isToday() {
-        return date.equals(LocalDate.now());
-    }
 
+    @Exclude
+    public boolean isToday() {
+        return getLocalDate().equals(LocalDate.now());
+    }
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/entity/MealIngredient.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/entity/MealIngredient.java
@@ -1,5 +1,7 @@
 package com.iti.mealmate.data.meal.model.entity;
 
+import com.google.firebase.firestore.Exclude;
+
 import java.io.Serializable;
 import java.text.Normalizer;
 
@@ -23,6 +25,7 @@ public class MealIngredient implements Serializable {
         return measure;
     }
 
+    @Exclude
     public String getImageUrl() {
         if (name == null || name.isEmpty()) return"";
         String normalized = Normalizer.normalize(name, Normalizer.Form.NFD)

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/entity/PlannedMeal.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/entity/PlannedMeal.java
@@ -1,14 +1,19 @@
 package com.iti.mealmate.data.meal.model.entity;
 
+import com.google.firebase.firestore.Exclude;
+
 import java.time.LocalDate;
 
 public class PlannedMeal {
     private Meal meal;
-    private LocalDate plannedDate;
+    private String plannedDate;
+
+    public PlannedMeal() {
+    }
 
     public PlannedMeal(Meal meal, LocalDate plannedDate) {
         this.meal = meal;
-        this.plannedDate = plannedDate;
+        this.plannedDate = plannedDate.toString();
     }
 
     public Meal getMeal() {
@@ -18,12 +23,20 @@ public class PlannedMeal {
     public void setMeal(Meal meal) {
         this.meal = meal;
     }
-
-    public LocalDate getPlannedDate() {
+    public String getPlannedDate() {
         return plannedDate;
     }
 
-    public void setPlannedDate(LocalDate plannedDate) {
+    public void setPlannedDate(String plannedDate) {
         this.plannedDate = plannedDate;
+    }
+
+    @Exclude
+    public LocalDate getPlannedLocalDate() {
+        return plannedDate != null ? LocalDate.parse(plannedDate) : null;
+    }
+
+    public void setPlannedLocalDate(LocalDate plannedDate) {
+        this.plannedDate = plannedDate != null ? plannedDate.toString() : null;
     }
 }

--- a/app/src/main/java/com/iti/mealmate/data/meal/model/mapper/PlanMapper.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/model/mapper/PlanMapper.java
@@ -27,14 +27,14 @@ public class PlanMapper {
     public static PlannedMealEntity createPlannedEntity(PlannedMeal plannedMeal) {
         return new PlannedMealEntity(
                 plannedMeal.getMeal().getId(),
-                DateUtils.dateToTimeStamp(plannedMeal.getPlannedDate()));
+                DateUtils.dateToTimeStamp(plannedMeal.getPlannedLocalDate()));
     }
 
 
     public static List<DayPlan> groupByDay(List<PlannedMealDetailEntity> mealDetails) {
         return mealDetails.stream()
                 .map(PlanMapper::toPlannedMealEntity)
-                .collect(Collectors.groupingBy(PlannedMeal::getPlannedDate, Collectors.toList()))
+                .collect(Collectors.groupingBy(PlannedMeal::getPlannedLocalDate, Collectors.toList()))
                 .entrySet().stream()
                 .map(e -> new DayPlan(e.getKey(), e.getValue()))
                 .sorted(Comparator.comparing(DayPlan::getDate))

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/favorite/FavoriteRepository.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/favorite/FavoriteRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface FavoriteRepository {
 
-    Flowable<List<Meal>> getAllFavoriteIds(String uid);
+    Flowable<List<Meal>> getAllFavorites(String uid);
 
     Single<Boolean> isFavorite(String mealId);
 

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/plan/PlanRepository.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/plan/PlanRepository.java
@@ -6,7 +6,6 @@ import com.iti.mealmate.data.meal.model.entity.PlannedMeal;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public interface PlanRepository {

--- a/app/src/main/java/com/iti/mealmate/data/meal/repo/sync/SyncRepositoryImpl.java
+++ b/app/src/main/java/com/iti/mealmate/data/meal/repo/sync/SyncRepositoryImpl.java
@@ -35,13 +35,11 @@ public class SyncRepositoryImpl implements SyncRepository {
     public Completable syncFavorites(String uid) {
         return favoriteLocalDataSource.getUserFavorites()
                 .firstOrError()
-                .flatMapCompletable(favorites -> {
-                    if (favorites.isEmpty()) return Completable.complete();
-                    return RxTask.withConnectivity(
-                            syncDataSource.uploadFavorites(uid, MealMapper.cachedEntitiesToDomain(favorites)).toSingleDefault(Void.TYPE),
-                            connectivityManager
-                    ).ignoreElement();
-                })
+                .flatMapCompletable(favorites -> RxTask.withConnectivity(
+                        syncDataSource.uploadFavorites(uid, MealMapper
+                                .cachedEntitiesToDomain(favorites)).toSingleDefault(Void.TYPE),
+                        connectivityManager
+                ).ignoreElement())
                 .onErrorResumeNext(throwable -> Completable.error(AppErrorHandler.handle(throwable)));
     }
 
@@ -52,15 +50,13 @@ public class SyncRepositoryImpl implements SyncRepository {
 
         return planLocalDataSource.getMealsForDateRange(start, end)
                 .firstOrError()
-                .flatMapCompletable(dayPlans -> {
-                    if (dayPlans.isEmpty()) return Completable.complete();
-                    return RxTask.withConnectivity(
-                            syncDataSource.uploadPlans(uid, PlanMapper.groupByDay(dayPlans))
-                                    .toSingleDefault(Void.TYPE),
-                            connectivityManager
-                    ).ignoreElement();
-                })
-                .onErrorResumeNext(throwable -> Completable.error(AppErrorHandler.handle(throwable)));
+                .flatMapCompletable(dayPlans -> RxTask.withConnectivity(
+                        syncDataSource.uploadPlans(uid, PlanMapper.groupByDay(dayPlans))
+                                .toSingleDefault(Void.TYPE),
+                        connectivityManager
+                ).ignoreElement())
+                .onErrorResumeNext(throwable ->
+                        Completable.error(AppErrorHandler.handle(throwable)));
     }
 
     @Override

--- a/app/src/main/java/com/iti/mealmate/data/source/local/db/AppDatabase.java
+++ b/app/src/main/java/com/iti/mealmate/data/source/local/db/AppDatabase.java
@@ -40,8 +40,4 @@ public abstract class AppDatabase extends RoomDatabase {
         }
         return INSTANCE;
     }
-
-    public synchronized void clearAll() {
-        INSTANCE.clearAllTables();
-    }
 }

--- a/app/src/main/java/com/iti/mealmate/ui/favorites/view/FavoriteUiStateHandler.java
+++ b/app/src/main/java/com/iti/mealmate/ui/favorites/view/FavoriteUiStateHandler.java
@@ -17,25 +17,47 @@ public class FavoriteUiStateHandler {
         hideGuestMode();
         binding.rvFavorites.setVisibility(View.GONE);
         binding.emptyStateLayout.emptyStateContainer.setVisibility(View.GONE);
+        binding.errorOverlay.getRoot().setVisibility(View.GONE);
+        binding.shimmerLayout.getRoot().setVisibility(View.VISIBLE);
+        binding.shimmerLayout.shimmerContainer.startShimmer();
     }
 
     public void showContent() {
         hideGuestMode();
+        binding.shimmerLayout.shimmerContainer.stopShimmer();
+        binding.shimmerLayout.getRoot().setVisibility(View.GONE);
+        binding.errorOverlay.getRoot().setVisibility(View.GONE);
         binding.rvFavorites.setVisibility(View.VISIBLE);
         binding.emptyStateLayout.emptyStateContainer.setVisibility(View.GONE);
     }
 
     public void showEmptyState(String message) {
         hideGuestMode();
+        binding.shimmerLayout.shimmerContainer.stopShimmer();
+        binding.shimmerLayout.getRoot().setVisibility(View.GONE);
+        binding.errorOverlay.getRoot().setVisibility(View.GONE);
         binding.rvFavorites.setVisibility(View.GONE);
         binding.emptyStateLayout.emptyStateContainer.setVisibility(View.VISIBLE);
         binding.emptyStateLayout.textEmptyState.setText(message);
     }
 
     public void showGuestMode(Activity activity) {
+        binding.shimmerLayout.shimmerContainer.stopShimmer();
+        binding.shimmerLayout.getRoot().setVisibility(View.GONE);
+        binding.errorOverlay.getRoot().setVisibility(View.GONE);
         binding.rvFavorites.setVisibility(View.GONE);
         binding.emptyStateLayout.emptyStateContainer.setVisibility(View.GONE);
         GuestOverlayHelper.showGuestOverlay(binding.getRoot(), activity);
+    }
+
+    public void showErrorPage(String message) {
+        hideGuestMode();
+        binding.shimmerLayout.shimmerContainer.stopShimmer();
+        binding.shimmerLayout.getRoot().setVisibility(View.GONE);
+        binding.rvFavorites.setVisibility(View.GONE);
+        binding.emptyStateLayout.emptyStateContainer.setVisibility(View.GONE);
+        binding.errorOverlay.getRoot().setVisibility(View.VISIBLE);
+        binding.errorOverlay.errorSubtitle.setText(message);
     }
 
     public void hideGuestMode() {
@@ -43,6 +65,9 @@ public class FavoriteUiStateHandler {
     }
 
     public void hideEmptyState() {
+        binding.shimmerLayout.shimmerContainer.stopShimmer();
+        binding.shimmerLayout.getRoot().setVisibility(View.GONE);
+        binding.errorOverlay.getRoot().setVisibility(View.GONE);
         binding.emptyStateLayout.emptyStateContainer.setVisibility(View.GONE);
         binding.rvFavorites.setVisibility(View.VISIBLE);
     }

--- a/app/src/main/java/com/iti/mealmate/ui/favorites/view/FavoritesFragment.java
+++ b/app/src/main/java/com/iti/mealmate/ui/favorites/view/FavoritesFragment.java
@@ -78,8 +78,10 @@ public class FavoritesFragment extends Fragment implements FavoriteView {
         uiStateHandler.showEmptyState(getString(R.string.no_favorites_message));
     }
 
+
     @Override
     public void showLoading() {
+        uiStateHandler.showLoading();
     }
 
     @Override
@@ -88,7 +90,7 @@ public class FavoritesFragment extends Fragment implements FavoriteView {
 
     @Override
     public void showPageError(String message) {
-        ActivityExtensions.showErrorSnackBar(requireActivity(), message);
+        uiStateHandler.showErrorPage(message);
     }
 
     @Override

--- a/app/src/main/java/com/iti/mealmate/ui/plan/view/PlanFragment.java
+++ b/app/src/main/java/com/iti/mealmate/ui/plan/view/PlanFragment.java
@@ -121,7 +121,7 @@ public class PlanFragment extends Fragment implements PlanView {
 
     @Override
     public void showPageError(String message) {
-        PlanView.super.showPageError(message);
+        planUiStateHandler.showErrorPage(message);
     }
 
     @Override

--- a/app/src/main/java/com/iti/mealmate/ui/plan/view/PlanUiStateHandler.java
+++ b/app/src/main/java/com/iti/mealmate/ui/plan/view/PlanUiStateHandler.java
@@ -2,6 +2,7 @@ package com.iti.mealmate.ui.plan.view;
 
 import android.app.Activity;
 import android.graphics.Typeface;
+import android.util.Log;
 import android.view.View;
 import android.view.animation.DecelerateInterpolator;
 import android.widget.FrameLayout;
@@ -25,21 +26,42 @@ public class PlanUiStateHandler {
 
     public void showLoading() {
         hideGuestMode();
-        binding.recyclerPlan.setVisibility(View.GONE);
+        binding.scrollableContent.setVisibility(View.INVISIBLE);
         binding.emptyStateLayout.emptyStateContainer.setVisibility(View.GONE);
+        binding.errorOverlay.getRoot().setVisibility(View.GONE);
+        binding.shimmerLayout.getRoot().setVisibility(View.VISIBLE);
+        binding.shimmerLayout.shimmerContainer.startShimmer();
     }
 
     public void showContent() {
         hideGuestMode();
+        binding.scrollableContent.setVisibility(View.VISIBLE);
+        binding.shimmerLayout.shimmerContainer.stopShimmer();
+        binding.shimmerLayout.getRoot().setVisibility(View.GONE);
+        binding.errorOverlay.getRoot().setVisibility(View.GONE);
         binding.recyclerPlan.setVisibility(View.VISIBLE);
         binding.emptyStateLayout.emptyStateContainer.setVisibility(View.GONE);
     }
 
     public void showEmptyState(String message) {
         hideGuestMode();
+        binding.shimmerLayout.shimmerContainer.stopShimmer();
+        binding.shimmerLayout.getRoot().setVisibility(View.GONE);
+        binding.errorOverlay.getRoot().setVisibility(View.GONE);
+        binding.scrollableContent.setVisibility(View.VISIBLE);
+        binding.recyclerPlan.setVisibility(View.GONE);
         binding.recyclerPlan.setVisibility(View.GONE);
         binding.emptyStateLayout.emptyStateContainer.setVisibility(View.VISIBLE);
         binding.emptyStateLayout.textEmptyState.setText(message);
+    }
+
+    public void showErrorPage(String message) {
+        hideGuestMode();
+        binding.shimmerLayout.shimmerContainer.stopShimmer();
+        binding.shimmerLayout.getRoot().setVisibility(View.GONE);
+        binding.scrollableContent.setVisibility(View.GONE);
+        binding.errorOverlay.getRoot().setVisibility(View.VISIBLE);
+        binding.errorOverlay.errorSubtitle.setText(message);
     }
 
     public void showGuestMode(Activity activity) {

--- a/app/src/main/java/com/iti/mealmate/ui/plan/view/adapter/PlansAdapter.java
+++ b/app/src/main/java/com/iti/mealmate/ui/plan/view/adapter/PlansAdapter.java
@@ -65,7 +65,7 @@ public class PlansAdapter
 
         boolean isExpanded = expandedStates.get(position, false);
 
-        holder.binding.textDayName.setText(plan.getDate().getDayOfWeek().name());
+        holder.binding.textDayName.setText(plan.getLocalDate().getDayOfWeek().name());
 
         holder.binding.textTodayBadge.setVisibility(
                 plan.isToday() ? View.VISIBLE : View.GONE

--- a/app/src/main/res/layout/fragment_favorites.xml
+++ b/app/src/main/res/layout/fragment_favorites.xml
@@ -31,8 +31,31 @@
         app:layout_constraintEnd_toEndOf="parent" />
 
     <include
+        android:id="@+id/shimmer_layout"
+        android:layout_margin="16dp"
+        layout="@layout/layout_discover_shimmer_overlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <include
         android:id="@+id/guest_overlay"
         layout="@layout/layout_guest_overlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <include
+        android:id="@+id/error_overlay"
+        layout="@layout/layout_error_overlay"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:visibility="gone"

--- a/app/src/main/res/layout/fragment_plan.xml
+++ b/app/src/main/res/layout/fragment_plan.xml
@@ -92,15 +92,29 @@
                 tools:itemCount="5"
                 tools:listitem="@layout/item_plan_day" />
 
+
+            <include
+                android:id="@+id/empty_state_layout"
+                layout="@layout/layout_empty_state"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@id/text_date_range"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
 
+
+
     <include
-        android:id="@+id/empty_state_layout"
-        layout="@layout/layout_empty_state"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="visible"
+        android:id="@+id/shimmer_layout"
+        layout="@layout/layout_plan_shimmer_overlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -109,6 +123,17 @@
     <include
         android:id="@+id/guest_overlay"
         layout="@layout/layout_guest_overlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <include
+        android:id="@+id/error_overlay"
+        layout="@layout/layout_error_overlay"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:visibility="gone"

--- a/app/src/main/res/layout/layout_plan_shimmer_overlay.xml
+++ b/app/src/main/res/layout/layout_plan_shimmer_overlay.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.facebook.shimmer.ShimmerFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/shimmer_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:shimmer_auto_start="false"
+    app:shimmer_base_alpha="0.7"
+    app:shimmer_highlight_alpha="1.0"
+    app:shimmer_direction="left_to_right"
+    app:shimmer_duration="1000"
+    app:shimmer_repeat_count="-1">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp">
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="38dp"
+            android:background="@drawable/shimmer_placeholder"
+            android:layout_marginBottom="16dp" />
+
+        <View
+            android:layout_width="140dp"
+            android:layout_height="14dp"
+            android:background="@drawable/shimmer_placeholder"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="24dp" />
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:layout_marginHorizontal="4dp"
+            app:cardBackgroundColor="@color/colorSurface"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="2dp">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp">
+
+                <View
+                    android:layout_width="120dp"
+                    android:layout_height="20dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <View
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="12dp"
+                    app:layout_constraintTop_toBottomOf="parent"
+                    tools:ignore="MissingConstraints" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:layout_marginHorizontal="4dp"
+            app:cardBackgroundColor="@color/colorSurface"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="2dp">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp">
+
+                <View
+                    android:layout_width="160dp"
+                    android:layout_height="20dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <View
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:layout_marginHorizontal="4dp"
+            app:cardBackgroundColor="@color/colorSurface"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="2dp">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp">
+
+                <View
+                    android:layout_width="100dp"
+                    android:layout_height="20dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <View
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:background="@drawable/shimmer_placeholder"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+
+    </LinearLayout>
+
+</com.facebook.shimmer.ShimmerFrameLayout>


### PR DESCRIPTION

- Add `layout_plan_shimmer_overlay.xml` and integrate shimmer loading effects into `PlanFragment` and `FavoritesFragment` using `PlanUiStateHandler` and `FavoriteUiStateHandler`.
- Implement centralized error overlays in Plan and Favorites screens to handle failure states gracefully.
- Enhance `FavoriteRepository` and `PlanRepository` to prioritize local data and fetch from remote sources only when local storage is empty.
- Update `ProfilePresenterImpl` to use `PreferencesHelper` for UID retrieval and ensure local database tables are cleared upon logout.
- Fix Firestore serialization issues by converting `LocalDate` fields to `String` in `DayPlan` and `PlannedMeal` entities and adding `@Exclude` to incompatible getters.
- Refactor `SyncRepositoryImpl` to remove redundant empty-check logic, delegating connectivity handling to `RxTask`.
- Improve `FavoritesFragment` and `PlanFragment` UI state transitions (loading, content, empty, error) through their respective state handlers.
- Update `PlansAdapter` to use the new `getLocalDate()` method for displaying day names correctly.
